### PR TITLE
Claim endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -1,19 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.controllers
 
-import org.json.JSONObject
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
-import org.springframework.web.bind.annotation.*
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.AuditService
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.SubjectAccessRequestService
-import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 @RestController
 @RequestMapping("/api/")
@@ -23,15 +22,12 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
     auditService.createEvent(authentication.name, "CREATE_SUBJECT_ACCESS_REQUEST", "Create Subject Access Request Report")
     val response = subjectAccessRequestService.createSubjectAccessRequestPost(request, authentication, requestTime)
     return response
-
   }
 
   @GetMapping("subjectAccessRequest")
   fun getSubjectAccessRequests(@RequestParam(required = false, name = "unclaimed") unclaimed: Boolean = false): List<SubjectAccessRequest?> {
-
     val response = subjectAccessRequestService.getSubjectAccessRequests(unclaimed)
-
-    //auditService.createEvent(SAR DEETS)
+    // auditService.createEvent(SAR DEETS)
     return response
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.controllers
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,7 +22,13 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
   fun createSubjectAccessRequestPost(@RequestBody request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
     auditService.createEvent(authentication.name, "CREATE_SUBJECT_ACCESS_REQUEST", "Create Subject Access Request Report")
     val response = subjectAccessRequestService.createSubjectAccessRequestPost(request, authentication, requestTime)
-    return response
+    return if(response == "") {
+      ResponseEntity(response, HttpStatus.OK)
+    }
+    else {
+      ResponseEntity(response, HttpStatus.BAD_REQUEST)
+    }
+
   }
 
   @GetMapping("subjectAccessRequest")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -22,13 +22,11 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
   fun createSubjectAccessRequestPost(@RequestBody request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
     auditService.createEvent(authentication.name, "CREATE_SUBJECT_ACCESS_REQUEST", "Create Subject Access Request Report")
     val response = subjectAccessRequestService.createSubjectAccessRequestPost(request, authentication, requestTime)
-    return if(response == "") {
+    return if (response == "") {
       ResponseEntity(response, HttpStatus.OK)
-    }
-    else {
+    } else {
       ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
-
   }
 
   @GetMapping("subjectAccessRequest")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import java.time.LocalDateTime
@@ -27,7 +28,7 @@ class SubjectAccessRequestGateway(
 
     return response
   }
-  fun saveSubjectAccessRequest() {
-
+  fun saveSubjectAccessRequest(sar: SubjectAccessRequest) {
+    repo.save(sar)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -11,23 +11,10 @@ import java.time.LocalDateTime
 class SubjectAccessRequestGateway(@Autowired val repo: SubjectAccessRequestRepository) {
   fun getSubjectAccessRequests(unclaimedOnly: Boolean, currentTime: LocalDateTime = LocalDateTime.now()): List<SubjectAccessRequest?> {
     if (unclaimedOnly) {
-
-//      val subjectAccessRequests: List<SubjectAccessRequest?> = emptyList()
-
       val sarsWithNoClaims = repo.findByClaimAttemptsIs(0)
-
       val sarsWithExpiredClaims = repo.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, currentTime.minusMinutes(5))
-
-
-      // val expiredClaimDate = LocalDateTime.(Now.fiveMinutesAgo)
-      // repo.findByStatusAndClaimAttemptsOrClaimDateTime(status: "pending", claimAttempts: "0")
-
-//      val subjectAccessRequests: List<SubjectAccessRequest?> = repo.findByClaimAttemptsIs(0)
-//          status == pending
-//          AND
-//          claimAttempts == 0
-//          OR claimDateTime == before expiredClaimDate
-//
+      val completeList = sarsWithNoClaims.plus(sarsWithExpiredClaims)
+      return completeList
     }
     val response = repo.findAll()
     return response

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -27,4 +27,7 @@ class SubjectAccessRequestGateway(
 
     return response
   }
+  fun saveSubjectAccessRequest() {
+
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -2,21 +2,32 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+import java.time.LocalDateTime
+
 @Component
 class SubjectAccessRequestGateway(@Autowired val repo: SubjectAccessRequestRepository) {
-  fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
+  fun getSubjectAccessRequests(unclaimedOnly: Boolean, currentTime: LocalDateTime = LocalDateTime.now()): List<SubjectAccessRequest?> {
     if (unclaimedOnly) {
+
+//      val subjectAccessRequests: List<SubjectAccessRequest?> = emptyList()
+
+      val sarsWithNoClaims = repo.findByClaimAttemptsIs(0)
+
+      val sarsWithExpiredClaims = repo.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, currentTime.minusMinutes(5))
+
+
       // val expiredClaimDate = LocalDateTime.(Now.fiveMinutesAgo)
       // repo.findByStatusAndClaimAttemptsOrClaimDateTime(status: "pending", claimAttempts: "0")
-      val subjectAccessRequests: List<SubjectAccessRequest?> = repo.findByClaimAttemptsIs(0)
+
+//      val subjectAccessRequests: List<SubjectAccessRequest?> = repo.findByClaimAttemptsIs(0)
 //          status == pending
 //          AND
 //          claimAttempts == 0
 //          OR claimDateTime == before expiredClaimDate
 //
-      return subjectAccessRequests
     }
     val response = repo.findAll()
     return response

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+import java.time.LocalDateTime
+
+class SubjectAccessRequestGateway(
+  @Autowired val repo: SubjectAccessRequestRepository) {
+  fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
+
+    if (unclaimedOnly) {
+      //val expiredClaimDate = LocalDateTime.(Now.fiveMinutesAgo)
+
+      // repo.findByStatusAndClaimAttemptsOrClaimDateTime(status: "pending", claimAttempts: "0")
+      val subjectAccessRequests: List<SubjectAccessRequest?> = repo.findByClaimAttemptsIs(0)
+//          status == pending
+//          AND
+//          claimAttempts == 0
+//          OR claimDateTime == before expiredClaimDate
+//
+            return subjectAccessRequests
+    }
+    val response = repo.findAll()
+
+    return response
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -1,20 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
-import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 @Component
-class SubjectAccessRequestGateway(
-  @Autowired val repo: SubjectAccessRequestRepository) {
+class SubjectAccessRequestGateway(@Autowired val repo: SubjectAccessRequestRepository) {
   fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
-
     if (unclaimedOnly) {
-      //val expiredClaimDate = LocalDateTime.(Now.fiveMinutesAgo)
-
+      // val expiredClaimDate = LocalDateTime.(Now.fiveMinutesAgo)
       // repo.findByStatusAndClaimAttemptsOrClaimDateTime(status: "pending", claimAttempts: "0")
       val subjectAccessRequests: List<SubjectAccessRequest?> = repo.findByClaimAttemptsIs(0)
 //          status == pending
@@ -22,10 +16,9 @@ class SubjectAccessRequestGateway(
 //          claimAttempts == 0
 //          OR claimDateTime == before expiredClaimDate
 //
-            return subjectAccessRequests
+      return subjectAccessRequests
     }
     val response = repo.findAll()
-
     return response
   }
   fun saveSubjectAccessRequest(sar: SubjectAccessRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -2,10 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import java.time.LocalDateTime
-
+@Component
 class SubjectAccessRequestGateway(
   @Autowired val repo: SubjectAccessRequestRepository) {
   fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -6,12 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectA
 
 @Repository
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, Int> {
-  abstract fun findByClaimAttemptsIs(claimAttempts: Int): List<SubjectAccessRequest?>
-// save() is a built in method of JpaRepository. This method below would have extended that so isn't required
-//  fun save(report: Report) {
-//    db.update(
-//      "Inserting into SAR table values ( ?, ? )",
-//      report.id, report.status
-//    )
-//  }
+
+  fun findByClaimAttemptsIs(claimAttempts: Int): List<SubjectAccessRequest?>
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -7,4 +7,6 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectA
 @Repository
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, Int> {
   fun findByClaimAttemptsIs(claimAttempts: Int): List<SubjectAccessRequest?>
+
+//  fun findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(status: String): List<SubjectAccessRequest?>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -6,7 +6,5 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectA
 
 @Repository
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, Int> {
-
   fun findByClaimAttemptsIs(claimAttempts: Int): List<SubjectAccessRequest?>
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+import java.time.LocalDateTime
 
 @Repository
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, Int> {
   fun findByClaimAttemptsIs(claimAttempts: Int): List<SubjectAccessRequest?>
 
-//  fun findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(status: String): List<SubjectAccessRequest?>
+  fun findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(status: Status, claimAttempts: Int, claimDateTime: LocalDateTime): List<SubjectAccessRequest?>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectA
 
 @Repository
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, Int> {
+  abstract fun findByClaimAttemptsIs(claimAttempts: Int): List<SubjectAccessRequest?>
 // save() is a built in method of JpaRepository. This method below would have extended that so isn't required
 //  fun save(report: Report) {
 //    db.update(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -18,7 +18,7 @@ class SubjectAccessRequestService(
   @Autowired val sarDbGateway: SubjectAccessRequestGateway,
 ) {
 
-  fun createSubjectAccessRequestPost(request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
+  fun createSubjectAccessRequestPost(request: String, authentication: Authentication, requestTime: LocalDateTime?): String {
     val json = JSONObject(request)
     val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
     val dateFrom = json.get("dateFrom").toString()
@@ -27,15 +27,9 @@ class SubjectAccessRequestService(
     val dateToFormatted = LocalDate.parse(dateTo, formatter)
 
     if (json.get("nomisId") != "" && json.get("ndeliusId") != "") {
-      return ResponseEntity(
-        "Both nomisId and ndeliusId are provided - exactly one is required",
-        HttpStatus.BAD_REQUEST,
-      )
+      return "Both nomisId and ndeliusId are provided - exactly one is required"
     } else if (json.get("nomisId") == "" && json.get("ndeliusId") == "") {
-      return ResponseEntity(
-        "Neither nomisId nor ndeliusId is provided - exactly one is required",
-        HttpStatus.BAD_REQUEST,
-      )
+      return "Neither nomisId nor ndeliusId is provided - exactly one is required"
     }
     sarDbGateway.saveSubjectAccessRequest(
       SubjectAccessRequest(
@@ -51,7 +45,7 @@ class SubjectAccessRequestService(
         requestDateTime = requestTime ?: LocalDateTime.now(),
       ),
     )
-    return ResponseEntity("", HttpStatus.OK); // Maybe want to return Report ID?
+    return "" // Maybe want to return Report ID?
   }
   fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
     val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -9,14 +9,13 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
 class SubjectAccessRequestService(
-  @Autowired val sarDbGateway: SubjectAccessRequestGateway
+  @Autowired val sarDbGateway: SubjectAccessRequestGateway,
 ) {
 
   fun createSubjectAccessRequestPost(request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
@@ -50,17 +49,12 @@ class SubjectAccessRequestService(
         ndeliusCaseReferenceId = json.get("ndeliusId").toString(),
         requestedBy = authentication.name,
         requestDateTime = requestTime ?: LocalDateTime.now(),
-      )
+      ),
     )
-
     return ResponseEntity("", HttpStatus.OK); // Maybe want to return Report ID?
   }
   fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
-
     val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly)
     return subjectAccessRequests
   }
-
-
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+class SubjectAccessRequestService(
+  @Autowired val sarDbGateway: SubjectAccessRequestGateway) {
+
+  fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
+
+    val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly)
+    return subjectAccessRequests
+  }
+
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
 
 import org.json.JSONObject
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+@Service
 class SubjectAccessRequestService(
   @Autowired val sarDbGateway: SubjectAccessRequestGateway) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -1,19 +1,66 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
 
+import org.json.JSONObject
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 @Service
 class SubjectAccessRequestService(
-  @Autowired val sarDbGateway: SubjectAccessRequestGateway) {
+  @Autowired val sarDbGateway: SubjectAccessRequestGateway, @Autowired val repo: SubjectAccessRequestRepository
+) {
 
+  fun createSubjectAccessRequestPost(request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
+    val json = JSONObject(request)
+    val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+    val dateFrom = json.get("dateFrom").toString()
+    val dateFromFormatted = if (dateFrom != "") LocalDate.parse(dateFrom, formatter) else null
+    val dateTo = json.get("dateTo").toString()
+    val dateToFormatted = LocalDate.parse(dateTo, formatter)
+
+    if (json.get("nomisId") != "" && json.get("ndeliusId") != "") {
+      return ResponseEntity(
+        "Both nomisId and ndeliusId are provided - exactly one is required",
+        HttpStatus.BAD_REQUEST,
+      )
+    } else if (json.get("nomisId") == "" && json.get("ndeliusId") == "") {
+      return ResponseEntity(
+        "Neither nomisId nor ndeliusId is provided - exactly one is required",
+        HttpStatus.BAD_REQUEST,
+      )
+    }
+
+    repo.save(
+      SubjectAccessRequest(
+        id = null,
+        status = Status.Pending,
+        dateFrom = dateFromFormatted,
+        dateTo = dateToFormatted,
+        sarCaseReferenceNumber = json.get("sarCaseReferenceNumber").toString(),
+        services = json.get("services").toString(),
+        nomisId = json.get("nomisId").toString(),
+        ndeliusCaseReferenceId = json.get("ndeliusId").toString(),
+        requestedBy = authentication.name,
+        requestDateTime = requestTime ?: LocalDateTime.now(),
+      ),
+    )
+    return ResponseEntity("", HttpStatus.OK); // Maybe want to return Report ID?
+  }
   fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
 
     val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly)
     return subjectAccessRequests
   }
+
 
 
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter
 
 @Service
 class SubjectAccessRequestService(
-  @Autowired val sarDbGateway: SubjectAccessRequestGateway, @Autowired val repo: SubjectAccessRequestRepository
+  @Autowired val sarDbGateway: SubjectAccessRequestGateway
 ) {
 
   fun createSubjectAccessRequestPost(request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
@@ -38,8 +38,7 @@ class SubjectAccessRequestService(
         HttpStatus.BAD_REQUEST,
       )
     }
-
-    repo.save(
+    sarDbGateway.saveSubjectAccessRequest(
       SubjectAccessRequest(
         id = null,
         status = Status.Pending,
@@ -51,8 +50,9 @@ class SubjectAccessRequestService(
         ndeliusCaseReferenceId = json.get("ndeliusId").toString(),
         requestedBy = authentication.name,
         requestDateTime = requestTime ?: LocalDateTime.now(),
-      ),
+      )
     )
+
     return ResponseEntity("", HttpStatus.OK); // Maybe want to return Report ID?
   }
   fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions
 import org.json.JSONObject
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -84,16 +85,16 @@ class SubjectAccessRequestControllerTest {
     claimAttempts = 0,
   )
   @Test
-  fun `createSubjectAccessRequestPost returns 200 and passes data to repository`() {
+  fun `createSubjectAccessRequestPost calls service createSubjectAccessRequestPost and returns 200`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
-    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected = ResponseEntity("", HttpStatus.OK)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
       .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
-    verify(sarRepository, times(1)).save(sampleSAR)
+    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
@@ -101,13 +102,13 @@ class SubjectAccessRequestControllerTest {
   fun `createSubjectAccessRequestPost returns 400 and error string if both IDs are supplied`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
-    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected = ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
       .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
-    verify(sarRepository, times(0)).save(any())
+    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
@@ -115,13 +116,13 @@ class SubjectAccessRequestControllerTest {
   fun `createSubjectAccessRequestPost returns 400 and error string if neither ID is supplied`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
-    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected = ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
       .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
-    verify(sarRepository, times(0)).save(any())
+    verify(sarService, times(1)).createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
@@ -129,10 +130,10 @@ class SubjectAccessRequestControllerTest {
   fun `getSubjectAccessRequests is called with unclaimedOnly = true if specified in controller and returns list`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
-    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
-    val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
+    val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(sarService, auditService)
       .getSubjectAccessRequests(unclaimed = true)
-    verify(subjectAccessRequestService, times(1)).getSubjectAccessRequests(unclaimedOnly = true)
+    verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = true)
     Assertions.assertThatList(result)
   }
 
@@ -140,10 +141,10 @@ class SubjectAccessRequestControllerTest {
   fun `getSubjectAccessRequests is called with unclaimedOnly = false if unspecified in controller`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
-    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
-    val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
+    val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(sarService, auditService)
       .getSubjectAccessRequests()
-    verify(subjectAccessRequestService, times(1)).getSubjectAccessRequests(unclaimedOnly = false)
+    verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false)
   }
 
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.AuditService
@@ -12,15 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.Subjec
 import java.time.LocalDateTime
 
 class SubjectAccessRequestControllerTest {
-
-  private val ndeliusRequest = "{ " +
-    "dateFrom: '01/12/2023', " +
-    "dateTo: '03/01/2024', " +
-    "sarCaseReferenceNumber: '1234abc', " +
-    "services: '{1,2,4}', " +
-    "nomisId: '', " +
-    "ndeliusId: '1' " +
-    "}"
   private val requestTime = LocalDateTime.now()
   private val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
   private val auditService = Mockito.mock(AuditService::class.java)
@@ -28,10 +21,59 @@ class SubjectAccessRequestControllerTest {
 
   @Test
   fun `createSubjectAccessRequestPost calls service createSubjectAccessRequestPost with same parameters`() {
+    val ndeliusRequest = "{ " +
+      "dateFrom: '01/12/2023', " +
+      "dateTo: '03/01/2024', " +
+      "sarCaseReferenceNumber: '1234abc', " +
+      "services: '{1,2,4}', " +
+      "nomisId: '', " +
+      "ndeliusId: '1' " +
+      "}"
     Mockito.`when`(authentication.name).thenReturn("aName")
-    SubjectAccessRequestController(sarService, auditService)
+    Mockito.`when`(sarService.createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)).thenReturn("")
+    val result = SubjectAccessRequestController(sarService, auditService)
       .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
+    val expected: ResponseEntity<String> = ResponseEntity("", HttpStatus.OK)
     verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
+    Assertions.assertThat(result).isEqualTo(expected)
+  }
+
+  @Test
+  fun `createSubjectAccessRequestPost returns http error if both nomis and ndelius ids are provided`() {
+    Mockito.`when`(authentication.name).thenReturn("aName")
+    val ndeliusAndNomisRequest = "{ " +
+      "dateFrom: '01/12/2023', " +
+      "dateTo: '03/01/2024', " +
+      "sarCaseReferenceNumber: '1234abc', " +
+      "services: '{1,2,4}', " +
+      "nomisId: '1', " +
+      "ndeliusId: '1' " +
+      "}"
+    Mockito.`when`(sarService.createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)).thenReturn("Both nomisId and ndeliusId are provided - exactly one is required")
+    val response = SubjectAccessRequestController(sarService, auditService)
+      .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
+    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
+    val expected: ResponseEntity<String> = ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST,)
+    Assertions.assertThat(response).isEqualTo(expected)
+  }
+
+  @Test
+  fun `createSubjectAccessRequestPost returns http error if neither nomis nor ndelius ids are provided`() {
+    Mockito.`when`(authentication.name).thenReturn("aName")
+    val noIDRequest = "{ " +
+      "dateFrom: '01/12/2023', " +
+      "dateTo: '03/01/2024', " +
+      "sarCaseReferenceNumber: '1234abc', " +
+      "services: '{1,2,4}', " +
+      "nomisId: '', " +
+      "ndeliusId: '' " +
+      "}"
+    Mockito.`when`(sarService.createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)).thenReturn("Neither nomisId nor ndeliusId is provided - exactly one is required")
+    val response = SubjectAccessRequestController(sarService, auditService)
+      .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
+    verify(sarService, times(1)).createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
+    val expected: ResponseEntity<String> = ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST,)
+    Assertions.assertThat(response).isEqualTo(expected)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -1,25 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.controllers
 
 import org.assertj.core.api.Assertions
-import org.json.JSONObject
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.AuditService
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.SubjectAccessRequestService
-import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
 
 class SubjectAccessRequestControllerTest {
 
@@ -31,11 +21,11 @@ class SubjectAccessRequestControllerTest {
     "nomisId: '', " +
     "ndeliusId: '1' " +
     "}"
-
   private val requestTime = LocalDateTime.now()
   private val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
   private val auditService = Mockito.mock(AuditService::class.java)
   private val authentication: Authentication = Mockito.mock(Authentication::class.java)
+
   @Test
   fun `createSubjectAccessRequestPost calls service createSubjectAccessRequestPost with same parameters`() {
     Mockito.`when`(authentication.name).thenReturn("aName")
@@ -43,6 +33,7 @@ class SubjectAccessRequestControllerTest {
       .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
     verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
   }
+
   @Test
   fun `getSubjectAccessRequests is called with unclaimedOnly = true if specified in controller and returns list`() {
     val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(sarService, auditService)
@@ -57,5 +48,4 @@ class SubjectAccessRequestControllerTest {
       .getSubjectAccessRequests()
     verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false)
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -7,6 +7,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -22,6 +23,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 @DataJpaTest
 class SubjectAccessRequestControllerTest {
+  @Autowired
+  private val sarController: SubjectAccessRequestController? = null
   private val ndeliusRequest = "{ " +
     "dateFrom: '01/12/2023', " +
     "dateTo: '03/01/2024', " +
@@ -48,6 +51,7 @@ class SubjectAccessRequestControllerTest {
     "nomisId: '', " +
     "ndeliusId: '' " +
     "}"
+
   private val json = JSONObject(ndeliusRequest)
   private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
   private val dateFrom = json.get("dateFrom").toString()
@@ -66,6 +70,7 @@ class SubjectAccessRequestControllerTest {
     ndeliusCaseReferenceId = "1",
     requestedBy = "aName",
     requestDateTime = requestTime,
+    claimAttempts = 0,
   )
 
   private val sampleUnclaimedSAR = SubjectAccessRequest(
@@ -106,6 +111,7 @@ class SubjectAccessRequestControllerTest {
     val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
       .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
 
+
     verify(sarRepository, times(0)).save(any())
     Assertions.assertThat(result).isEqualTo(expected)
   }
@@ -132,14 +138,26 @@ class SubjectAccessRequestControllerTest {
     val auditService = Mockito.mock(AuditService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
     val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
-    Mockito.`when`(authentication.name).thenReturn("aName")
-    val expectedUnclaimed: List<SubjectAccessRequest> = listOf(sampleUnclaimedSAR)
-    SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
-      .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
+    //Mockito.`when`(authentication.name).thenReturn("aName")
+//    val sampleSAR = SubjectAccessRequest(
+//      id = null,
+//      status = Status.Pending,
+//      dateFrom = dateFromFormatted,
+//      dateTo = dateToFormatted,
+//      sarCaseReferenceNumber = "1234abc",
+//      services = "{1,2,4}",
+//      nomisId = "",
+//      ndeliusCaseReferenceId = "1",
+//      requestedBy = authentication.name,
+//      requestDateTime = requestTime,
+//    )
+    val expectedUnclaimed: List<SubjectAccessRequest> = listOf(sampleSAR)
+    //SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+    sarController?.createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
     val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
       .getSubjectAccessRequests(unclaimed = true)
-
+    //Assertions.assertThat(sarRepository.findAll()).isEqualTo(expectedUnclaimed)
     verify(subjectAccessRequestService, times(1)).getSubjectAccessRequests(unclaimedOnly = true)
-    Assertions.assertThat(result).isEqualTo(expectedUnclaimed)
+   // Assertions.assertThat(result).isEqualTo(expectedUnclaimed)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -53,7 +53,7 @@ class SubjectAccessRequestControllerTest {
     val response = SubjectAccessRequestController(sarService, auditService)
       .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
     verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
-    val expected: ResponseEntity<String> = ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST,)
+    val expected: ResponseEntity<String> = ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
     Assertions.assertThat(response).isEqualTo(expected)
   }
 
@@ -72,7 +72,7 @@ class SubjectAccessRequestControllerTest {
     val response = SubjectAccessRequestController(sarService, auditService)
       .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
     verify(sarService, times(1)).createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
-    val expected: ResponseEntity<String> = ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST,)
+    val expected: ResponseEntity<String> = ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)
     Assertions.assertThat(response).isEqualTo(expected)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -1,19 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.controllers
 
 import org.assertj.core.api.Assertions
-import org.hamcrest.core.IsInstanceOf.instanceOf
 import org.json.JSONObject
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
@@ -22,12 +18,10 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.Subjec
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import kotlin.reflect.typeOf
 
 
 class SubjectAccessRequestControllerTest {
 
-  private val sarController: SubjectAccessRequestController? = null
   private val ndeliusRequest = "{ " +
     "dateFrom: '01/12/2023', " +
     "dateTo: '03/01/2024', " +

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -10,57 +10,86 @@ import org.mockito.Mockito.verify
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.AuditService
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.SubjectAccessRequestService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 class SubjectAccessRequestControllerTest {
+  private val ndeliusRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '', " +
+    "ndeliusId: '1' " +
+    "}"
+
+  private val ndeliusAndNomisRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '1', " +
+    "ndeliusId: '1' " +
+    "}"
+
+  private val noIDRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '', " +
+    "ndeliusId: '' " +
+    "}"
+  private val json = JSONObject(ndeliusRequest)
+  private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  private val dateFrom = json.get("dateFrom").toString()
+  private val dateFromFormatted = LocalDate.parse(dateFrom, formatter)
+  private val dateTo = json.get("dateTo").toString()
+  private val dateToFormatted = LocalDate.parse(dateTo, formatter)
+  private val requestTime = LocalDateTime.now()
+  private val sampleSAR = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "aName",
+    requestDateTime = requestTime,
+  )
+
+  private val sampleUnclaimedSAR = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTime,
+    claimAttempts = 1,
+  )
   @Test
   fun `createSubjectAccessRequestPost returns 200 and passes data to repository`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
+    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
-
-    val request = "{ " +
-      "dateFrom: '01/12/2023', " +
-      "dateTo: '03/01/2024', " +
-      "sarCaseReferenceNumber: '1234abc', " +
-      "services: '{1,2,4}', " +
-      "nomisId: '', " +
-      "ndeliusId: '1' " +
-      "}"
-    val requestTime = LocalDateTime.now()
-
     val expected = ResponseEntity("", HttpStatus.OK)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(auditService, sarRepository)
-      .createSubjectAccessRequestPost(request, authentication, requestTime)
-
-    val json = JSONObject(request)
-    val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-    val dateFrom = json.get("dateFrom").toString()
-    val dateFromFormatted = LocalDate.parse(dateFrom, formatter)
-
-    val dateTo = json.get("dateTo").toString()
-    val dateToFormatted = LocalDate.parse(dateTo, formatter)
-
-    verify(sarRepository, times(1)).save(
-      SubjectAccessRequest(
-        id = null,
-        status = Status.Pending,
-        dateFrom = dateFromFormatted,
-        dateTo = dateToFormatted,
-        sarCaseReferenceNumber = "1234abc",
-        services = "{1,2,4}",
-        nomisId = "",
-        ndeliusCaseReferenceId = "1",
-        requestedBy = authentication.name,
-        requestDateTime = requestTime,
-      ),
-    )
+    val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+      .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
+    verify(sarRepository, times(1)).save(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
@@ -69,21 +98,11 @@ class SubjectAccessRequestControllerTest {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
+    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
-
-    val request = "{ " +
-      "dateFrom: '01/12/2023', " +
-      "dateTo: '03/01/2024', " +
-      "sarCaseReferenceNumber: '1234abc', " +
-      "services: '{1,2,4}', " +
-      "nomisId: '1', " +
-      "ndeliusId: '1' " +
-      "}"
-
-    val requestTime = LocalDateTime.now()
     val expected = ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(auditService, sarRepository)
-      .createSubjectAccessRequestPost(request, authentication, requestTime)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+      .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
 
     verify(sarRepository, times(0)).save(any())
     Assertions.assertThat(result).isEqualTo(expected)
@@ -94,23 +113,29 @@ class SubjectAccessRequestControllerTest {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
+    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
-
-    val requestTime = LocalDateTime.now()
-    val request = "{ " +
-      "dateFrom: '01/12/2023', " +
-      "dateTo: '03/01/2024', " +
-      "sarCaseReferenceNumber: '1234abc', " +
-      "services: '{1,2,4}', " +
-      "nomisId: '', " +
-      "ndeliusId: '' " +
-      "}"
-
     val expected = ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(auditService, sarRepository)
-      .createSubjectAccessRequestPost(request, authentication, requestTime)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+      .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
 
     verify(sarRepository, times(0)).save(any())
     Assertions.assertThat(result).isEqualTo(expected)
+  }
+
+  @Test
+  fun `getSubjectAccessRequests returns list`() {
+    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
+    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val auditService = Mockito.mock(AuditService::class.java)
+//    val authentication: Authentication = Mockito.mock(Authentication::class.java)
+    val subjectAccessRequestService = Mockito.mock(SubjectAccessRequestService::class.java)
+//    Mockito.`when`(authentication.name).thenReturn("aName")
+    val expectedUnclaimed: List<SubjectAccessRequest> = listOf(sampleUnclaimedSAR)
+    val result: List<SubjectAccessRequest?> = SubjectAccessRequestController(subjectAccessRequestService, auditService, sarRepository)
+      .getSubjectAccessRequests(true)
+
+    verify(sarGateway, times(1)).getSubjectAccessRequests(true)
+    Assertions.assertThat(result).isEqualTo(expectedUnclaimed)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -37,6 +37,7 @@ class SubjectAccessRequestGatewayTest {
     claimAttempts = 0,
   )
   private val mockSarsWithNoClaims = listOf(unclaimedSar, unclaimedSar, unclaimedSar)
+
   @Nested
   inner class getSubjectAccessRequests {
     private val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
@@ -82,13 +83,12 @@ class SubjectAccessRequestGatewayTest {
       val expiredClaimDateTime = "01/01/2024 23:55"
       val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
       Mockito.`when`(sarRepository.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)).thenReturn(
-        emptyList()
+        emptyList(),
       )
       val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
         .getSubjectAccessRequests(unclaimedOnly = true, formattedMockedCurrentTime)
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
       Assertions.assertTrue(result.size == 3)
     }
-
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -12,7 +12,7 @@ class SubjectAccessRequestGatewayTest {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
       .getSubjectAccessRequests(unclaimedOnly = false)
-    verify(sarRepository, times(1)).findAll();
+    verify(sarRepository, times(1)).findAll()
   }
 
   @Test
@@ -20,6 +20,6 @@ class SubjectAccessRequestGatewayTest {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
       .getSubjectAccessRequests(unclaimedOnly = true)
-    verify(sarRepository, times(1)).findByClaimAttemptsIs(0);
+    verify(sarRepository, times(1)).findByClaimAttemptsIs(0)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+class SubjectAccessRequestGatewayTest {
+  @Test
+  fun `gateway calls findAll if unclaimed is false`() {
+    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
+      .getSubjectAccessRequests(unclaimedOnly = false)
+    verify(sarRepository, times(1)).findAll();
+  }
+
+  @Test
+  fun `gateway calls if unclaimed is true`() {
+    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
+      .getSubjectAccessRequests(unclaimedOnly = true)
+    verify(sarRepository, times(1)).findByClaimAttemptsIs(0);
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -8,14 +9,39 @@ import org.mockito.Mockito.verify
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class SubjectAccessRequestGatewayTest {
+
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+  private val dateFrom = "01/12/2023"
+  private val dateFromFormatted = LocalDate.parse(dateFrom, dateFormatter)
+  private val dateTo = "03/01/2024"
+  private val dateToFormatted = LocalDate.parse(dateTo, dateFormatter)
+  private val requestTime = "01/01/2024 00:00"
+  private val requestTimeFormatted = LocalDateTime.parse(requestTime, dateTimeFormatter)
+  private val unclaimedSar = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTimeFormatted,
+    claimAttempts = 0,
+  )
+  private val mockSarsWithNoClaims = listOf(unclaimedSar, unclaimedSar, unclaimedSar)
   @Nested
   inner class getSubjectAccessRequests {
     private val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+
     @Test
     fun `calls findAll if unclaimed is false`() {
       val result = SubjectAccessRequestGateway(sarRepository)
@@ -43,10 +69,25 @@ class SubjectAccessRequestGatewayTest {
       val formattedMockedCurrentTime = LocalDateTime.parse(mockedCurrentTime, dateTimeFormatter)
       val expiredClaimDateTime = "01/01/2024 23:55"
       val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
-
       val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
         .getSubjectAccessRequests(unclaimedOnly = true, formattedMockedCurrentTime)
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
+    }
+
+    @Test
+    fun `returns joint list of both claimed and valid unclaimed sars`() {
+      Mockito.`when`(sarRepository.findByClaimAttemptsIs(0)).thenReturn(mockSarsWithNoClaims)
+      val mockedCurrentTime = "02/01/2024 00:00"
+      val formattedMockedCurrentTime = LocalDateTime.parse(mockedCurrentTime, dateTimeFormatter)
+      val expiredClaimDateTime = "01/01/2024 23:55"
+      val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
+      Mockito.`when`(sarRepository.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)).thenReturn(
+        emptyList()
+      )
+      val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
+        .getSubjectAccessRequests(unclaimedOnly = true, formattedMockedCurrentTime)
+      verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
+      Assertions.assertTrue(result.size == 3)
     }
 
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -1,25 +1,53 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
-class SubjectAccessRequestGatewayTest {
-  @Test
-  fun `gateway calls findAll if unclaimed is false`() {
-    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
-    val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
-      .getSubjectAccessRequests(unclaimedOnly = false)
-    verify(sarRepository, times(1)).findAll()
-  }
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
-  @Test
-  fun `gateway calls findByClaimAttemptsIs if unclaimed is true`() {
-    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
-    val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
-      .getSubjectAccessRequests(unclaimedOnly = true)
-    verify(sarRepository, times(1)).findByClaimAttemptsIs(0)
+class SubjectAccessRequestGatewayTest {
+  @Nested
+  inner class getSubjectAccessRequests {
+    private val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+    @Test
+    fun `calls findAll if unclaimed is false`() {
+      val result = SubjectAccessRequestGateway(sarRepository)
+        .getSubjectAccessRequests(unclaimedOnly = false)
+      verify(sarRepository, times(1)).findAll()
+    }
+
+    @Test
+    fun `calls findByClaimAttemptsIs if unclaimed is true`() {
+      val result = SubjectAccessRequestGateway(sarRepository)
+        .getSubjectAccessRequests(unclaimedOnly = true)
+      verify(sarRepository, times(1)).findByClaimAttemptsIs(0)
+    }
+
+    @Test
+    fun `calls findByClaimAttemptsIs(0) if unclaimed is true`() {
+      val result = SubjectAccessRequestGateway(sarRepository)
+        .getSubjectAccessRequests(unclaimedOnly = true)
+      verify(sarRepository, times(1)).findByClaimAttemptsIs(0)
+    }
+
+    @Test
+    fun `calls findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore if unclaimed is true`() {
+      val mockedCurrentTime = "02/01/2024 00:00"
+      val formattedMockedCurrentTime = LocalDateTime.parse(mockedCurrentTime, dateTimeFormatter)
+      val expiredClaimDateTime = "01/01/2024 23:55"
+      val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
+
+      val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
+        .getSubjectAccessRequests(unclaimedOnly = true, formattedMockedCurrentTime)
+      verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
+    }
+
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
-import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.times
@@ -17,7 +16,7 @@ class SubjectAccessRequestGatewayTest {
   }
 
   @Test
-  fun `gateway calls if unclaimed is true`() {
+  fun `gateway calls findByClaimAttemptsIs if unclaimed is true`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
       .getSubjectAccessRequests(unclaimedOnly = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -101,40 +101,49 @@ class SubjectAccessRequestRepositoryTest {
     claimDateTime = expiredClaimDateTimeFormatted,
   )
 
+  fun databaseInsert() {
+    sarRepository?.save(unclaimedSar)
+    sarRepository?.save(pendingSarWithExpiredClaim)
+    sarRepository?.save(pendingSarWithCurrentClaim)
+    sarRepository?.save(completedSarWithCurrentClaim)
+    sarRepository?.save(completedSarWithExpiredClaim)
+  }
+
+  val allSars = listOf(unclaimedSar, pendingSarWithExpiredClaim, pendingSarWithCurrentClaim, completedSarWithCurrentClaim, completedSarWithExpiredClaim)
+
   @Nested
   inner class findByClaimAttemptsIs {
     @Test
     fun `findByClaimAttemptsIs returns only unclaimed SAR entries if called with 0`() {
-      val expectedAll: List<SubjectAccessRequest> = listOf(unclaimedSar, pendingSarWithExpiredClaim)
       val expectedUnclaimed: List<SubjectAccessRequest> = listOf(unclaimedSar)
-      sarRepository?.save(unclaimedSar)
-      sarRepository?.save(pendingSarWithExpiredClaim)
-      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
+
+      databaseInsert()
+
+      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(allSars)
       Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(0)).isEqualTo(expectedUnclaimed)
     }
 
     @Test
     fun `findByClaimAttemptsIs returns only claimed SAR entries if called with 1 or more`() {
-      val expectedAll: List<SubjectAccessRequest> = listOf(pendingSarWithExpiredClaim, unclaimedSar)
-      val expectedClaimed: List<SubjectAccessRequest> = listOf(pendingSarWithExpiredClaim)
-      sarRepository?.save(pendingSarWithExpiredClaim)
-      sarRepository?.save(unclaimedSar)
-      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
+      val expectedClaimed: List<SubjectAccessRequest> = listOf(pendingSarWithExpiredClaim, pendingSarWithCurrentClaim, completedSarWithCurrentClaim, completedSarWithExpiredClaim)
+
+      databaseInsert()
+
+      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(allSars)
       Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(1)).isEqualTo(expectedClaimed)
     }
-
-    @Test
-    fun `db doesn't save between tests`() {
-      val emptyList: List<Any> = emptyList()
-      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(emptyList)
-    }
   }
-
-  @Nested
-  inner class findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore {
-    @Test
-    fun `returns only SAR entries with pending status and expired claim date-time if called with pending, 0 and old date-time`() {
-      val expectAll: List<SubjectAccessRequest> = listOf(unclaimedSar, unclaimedSar)
-    }
-  }
+//
+//  @Nested
+//  inner class findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore {
+//    @Test
+//    fun `returns only SAR entries with pending status and expired claim date-time if called with pending, 0 and old date-time`() {
+//      val expectedExpiredClaimed: List<SubjectAccessRequest> = listOf(unclaimedSar, pendingSarWithExpiredClaim, pendingSarWithCurrentClaim)
+//
+//      databaseInsert()
+//
+//      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(allSars)
+//      Assertions.assertThat(sarRepository?.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore("Pending")).isEqualTo(expectedExpiredClaimed)
+//    }
+//  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -4,14 +4,12 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-//@SpringBootTest
 @DataJpaTest
 class SubjectAccessRequestRepositoryTest {
 
@@ -63,7 +61,6 @@ class SubjectAccessRequestRepositoryTest {
   fun `findByClaimAttemptsIs returns only claimed SAR entries if called with 1 or more`() {
     val expectedAll: List<SubjectAccessRequest> = listOf(sampleClaimedSAR, sampleUnclaimedSAR)
     val expectedClaimed: List<SubjectAccessRequest> = listOf(sampleClaimedSAR)
-    val emptyList: List<Any> = emptyList()
     sarRepository?.save(sampleClaimedSAR)
     sarRepository?.save(sampleUnclaimedSAR)
     Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository
 
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -12,16 +13,25 @@ import java.time.format.DateTimeFormatter
 
 @DataJpaTest
 class SubjectAccessRequestRepositoryTest {
-
   @Autowired
   private val sarRepository: SubjectAccessRequestRepository? = null
-  private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+
   private val dateFrom = "01/12/2023"
-  private val dateFromFormatted = LocalDate.parse(dateFrom, formatter)
+  private val dateFromFormatted = LocalDate.parse(dateFrom, dateFormatter)
   private val dateTo = "03/01/2024"
-  private val dateToFormatted = LocalDate.parse(dateTo, formatter)
-  private val requestTime = LocalDateTime.now()
-  val sampleUnclaimedSAR = SubjectAccessRequest(
+  private val dateToFormatted = LocalDate.parse(dateTo, dateFormatter)
+  private val requestTime = "01/01/2024 00:00"
+  private val requestTimeFormatted = LocalDateTime.parse(requestTime, dateTimeFormatter)
+  private val expiredClaimDateTime = "02/01/2024 00:00"
+  private val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
+  private val currentClaimDateTime = "03/01/2024 00:00"
+  private val currentClaimDateTimeFormatted = LocalDateTime.parse(currentClaimDateTime, dateTimeFormatter)
+
+
+  val unclaimedSar = SubjectAccessRequest(
     id = null,
     status = Status.Pending,
     dateFrom = dateFromFormatted,
@@ -31,10 +41,10 @@ class SubjectAccessRequestRepositoryTest {
     nomisId = "",
     ndeliusCaseReferenceId = "1",
     requestedBy = "Test",
-    requestDateTime = requestTime,
+    requestDateTime = requestTimeFormatted,
     claimAttempts = 0,
   )
-  val sampleClaimedSAR = SubjectAccessRequest(
+  val pendingSarWithExpiredClaim = SubjectAccessRequest(
     id = null,
     status = Status.Pending,
     dateFrom = dateFromFormatted,
@@ -44,33 +54,87 @@ class SubjectAccessRequestRepositoryTest {
     nomisId = "",
     ndeliusCaseReferenceId = "1",
     requestedBy = "Test",
-    requestDateTime = requestTime,
+    requestDateTime = requestTimeFormatted,
     claimAttempts = 1,
+    claimDateTime = expiredClaimDateTimeFormatted,
+  )
+  val pendingSarWithCurrentClaim = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTimeFormatted,
+    claimAttempts = 1,
+    claimDateTime = currentClaimDateTimeFormatted,
+  )
+  val completedSarWithCurrentClaim = SubjectAccessRequest(
+    id = null,
+    status = Status.Completed, // here
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTimeFormatted,
+    claimAttempts = 1,
+    claimDateTime = currentClaimDateTimeFormatted,
+  )
+  val completedSarWithExpiredClaim = SubjectAccessRequest(
+    id = null,
+    status = Status.Completed, // here
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTimeFormatted,
+    claimAttempts = 1,
+    claimDateTime = expiredClaimDateTimeFormatted,
   )
 
-  @Test
-  fun `findByClaimAttemptsIs returns only unclaimed SAR entries if called with 0`() {
-    val expectedAll: List<SubjectAccessRequest> = listOf(sampleClaimedSAR, sampleUnclaimedSAR)
-    val expectedUnclaimed: List<SubjectAccessRequest> = listOf(sampleUnclaimedSAR)
-    sarRepository?.save(sampleClaimedSAR)
-    sarRepository?.save(sampleUnclaimedSAR)
-    Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
-    Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(0)).isEqualTo(expectedUnclaimed)
+  @Nested
+  inner class findByClaimAttemptsIs {
+    @Test
+    fun `findByClaimAttemptsIs returns only unclaimed SAR entries if called with 0`() {
+      val expectedAll: List<SubjectAccessRequest> = listOf(unclaimedSar, pendingSarWithExpiredClaim)
+      val expectedUnclaimed: List<SubjectAccessRequest> = listOf(unclaimedSar)
+      sarRepository?.save(unclaimedSar)
+      sarRepository?.save(pendingSarWithExpiredClaim)
+      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
+      Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(0)).isEqualTo(expectedUnclaimed)
+    }
+
+    @Test
+    fun `findByClaimAttemptsIs returns only claimed SAR entries if called with 1 or more`() {
+      val expectedAll: List<SubjectAccessRequest> = listOf(pendingSarWithExpiredClaim, unclaimedSar)
+      val expectedClaimed: List<SubjectAccessRequest> = listOf(pendingSarWithExpiredClaim)
+      sarRepository?.save(pendingSarWithExpiredClaim)
+      sarRepository?.save(unclaimedSar)
+      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
+      Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(1)).isEqualTo(expectedClaimed)
+    }
+
+    @Test
+    fun `db doesn't save between tests`() {
+      val emptyList: List<Any> = emptyList()
+      Assertions.assertThat(sarRepository?.findAll()).isEqualTo(emptyList)
+    }
   }
 
-  @Test
-  fun `findByClaimAttemptsIs returns only claimed SAR entries if called with 1 or more`() {
-    val expectedAll: List<SubjectAccessRequest> = listOf(sampleClaimedSAR, sampleUnclaimedSAR)
-    val expectedClaimed: List<SubjectAccessRequest> = listOf(sampleClaimedSAR)
-    sarRepository?.save(sampleClaimedSAR)
-    sarRepository?.save(sampleUnclaimedSAR)
-    Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
-    Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(1)).isEqualTo(expectedClaimed)
-  }
-
-  @Test
-  fun `db doesn't save between tests`() {
-    val emptyList: List<Any> = emptyList()
-    Assertions.assertThat(sarRepository?.findAll()).isEqualTo(emptyList)
+  @Nested
+  inner class findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore {
+    @Test
+    fun `returns only SAR entries with pending status and expired claim date-time if called with pending, 0 and old date-time`() {
+      val expectAll: List<SubjectAccessRequest> = listOf(unclaimedSar, unclaimedSar)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.SpringBootTest
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+//@SpringBootTest
+@DataJpaTest
+class SubjectAccessRequestRepositoryTest {
+
+  @Autowired
+  private val sarRepository: SubjectAccessRequestRepository? = null
+  private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  private val dateFrom = "01/12/2023"
+  private val dateFromFormatted = LocalDate.parse(dateFrom, formatter)
+  private val dateTo = "03/01/2024"
+  private val dateToFormatted = LocalDate.parse(dateTo, formatter)
+  private val requestTime = LocalDateTime.now()
+  val sampleUnclaimedSAR = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTime,
+    claimAttempts = 0,
+  )
+  val sampleClaimedSAR = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTime,
+    claimAttempts = 1,
+  )
+  @Test
+  fun `findByClaimAttemptsIs returns only unclaimed SAR entries if called with 0`() {
+    val expectedAll: List<SubjectAccessRequest> = listOf(sampleClaimedSAR, sampleUnclaimedSAR)
+    val expectedUnclaimed: List<SubjectAccessRequest> = listOf(sampleUnclaimedSAR)
+    sarRepository?.save(sampleClaimedSAR)
+    sarRepository?.save(sampleUnclaimedSAR)
+    Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
+    Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(0)).isEqualTo(expectedUnclaimed)
+  }
+
+  @Test
+  fun `findByClaimAttemptsIs returns only claimed SAR entries if called with 1 or more`() {
+    val expectedAll: List<SubjectAccessRequest> = listOf(sampleClaimedSAR, sampleUnclaimedSAR)
+    val expectedClaimed: List<SubjectAccessRequest> = listOf(sampleClaimedSAR)
+    val emptyList: List<Any> = emptyList()
+    sarRepository?.save(sampleClaimedSAR)
+    sarRepository?.save(sampleUnclaimedSAR)
+    Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
+    Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(1)).isEqualTo(expectedClaimed)
+  }
+  @Test
+  fun `db doesn't save between tests`() {
+    val emptyList: List<Any> = emptyList()
+    Assertions.assertThat(sarRepository?.findAll()).isEqualTo(emptyList)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -15,18 +15,16 @@ import java.time.format.DateTimeFormatter
 class SubjectAccessRequestRepositoryTest {
   @Autowired
   private val sarRepository: SubjectAccessRequestRepository? = null
-
   private val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
   private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
-
   private val dateFrom = "01/12/2023"
   private val dateFromFormatted = LocalDate.parse(dateFrom, dateFormatter)
   private val dateTo = "03/01/2024"
   private val dateToFormatted = LocalDate.parse(dateTo, dateFormatter)
   private val requestTime = "01/01/2024 00:00"
   private val requestTimeFormatted = LocalDateTime.parse(requestTime, dateTimeFormatter)
-  private val ClaimDateTime = "02/01/2024 00:00"
-  private val ClaimDateTimeFormatted = LocalDateTime.parse(ClaimDateTime, dateTimeFormatter)
+  private val claimDateTime = "02/01/2024 00:00"
+  private val claimDateTimeFormatted = LocalDateTime.parse(claimDateTime, dateTimeFormatter)
 
   val unclaimedSar = SubjectAccessRequest(
     id = null,
@@ -53,7 +51,7 @@ class SubjectAccessRequestRepositoryTest {
     requestedBy = "Test",
     requestDateTime = requestTimeFormatted,
     claimAttempts = 1,
-    claimDateTime = ClaimDateTimeFormatted,
+    claimDateTime = claimDateTimeFormatted,
   )
   val completedSar = SubjectAccessRequest(
     id = null,
@@ -67,7 +65,7 @@ class SubjectAccessRequestRepositoryTest {
     requestedBy = "Test",
     requestDateTime = requestTimeFormatted,
     claimAttempts = 1,
-    claimDateTime = ClaimDateTimeFormatted,
+    claimDateTime = claimDateTimeFormatted,
   )
 
   fun databaseInsert() {
@@ -75,7 +73,6 @@ class SubjectAccessRequestRepositoryTest {
     sarRepository?.save(claimedSarWithPendingStatus)
     sarRepository?.save(completedSar)
   }
-
   val allSars = listOf(unclaimedSar, claimedSarWithPendingStatus, completedSar)
 
   @Nested
@@ -83,9 +80,7 @@ class SubjectAccessRequestRepositoryTest {
     @Test
     fun `findByClaimAttemptsIs returns only unclaimed SAR entries if called with 0`() {
       val expectedUnclaimed: List<SubjectAccessRequest> = listOf(unclaimedSar)
-
       databaseInsert()
-
       Assertions.assertThat(sarRepository?.findAll()).isEqualTo(allSars)
       Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(0)).isEqualTo(expectedUnclaimed)
     }
@@ -93,9 +88,7 @@ class SubjectAccessRequestRepositoryTest {
     @Test
     fun `findByClaimAttemptsIs returns only claimed SAR entries if called with 1 or more`() {
       val expectedClaimed: List<SubjectAccessRequest> = listOf(claimedSarWithPendingStatus, completedSar)
-
       databaseInsert()
-
       Assertions.assertThat(sarRepository?.findAll()).isEqualTo(allSars)
       Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(1)).isEqualTo(expectedClaimed)
     }
@@ -107,7 +100,6 @@ class SubjectAccessRequestRepositoryTest {
     fun `returns only SAR entries with given criteria`() {
       val claimDateTimeEarlier = "02/01/2023 00:00"
       val claimDateTimeEarlierFormatted = LocalDateTime.parse(claimDateTimeEarlier, dateTimeFormatter)
-
       val sarWithPendingStatusClaimedEarlier = SubjectAccessRequest(
         id = null,
         status = Status.Pending,
@@ -122,14 +114,11 @@ class SubjectAccessRequestRepositoryTest {
         claimAttempts = 1,
         claimDateTime = claimDateTimeEarlierFormatted,
       )
-
       val expectedPendingClaimedBefore: List<SubjectAccessRequest> = listOf(sarWithPendingStatusClaimedEarlier)
-
       databaseInsert()
       sarRepository?.save(sarWithPendingStatusClaimedEarlier)
-
       Assertions.assertThat(sarRepository?.findAll()?.size).isEqualTo(4)
-      Assertions.assertThat(sarRepository?.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, ClaimDateTimeFormatted)).isEqualTo(expectedPendingClaimedBefore)
+      Assertions.assertThat(sarRepository?.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, claimDateTimeFormatted)).isEqualTo(expectedPendingClaimedBefore)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -47,6 +47,7 @@ class SubjectAccessRequestRepositoryTest {
     requestDateTime = requestTime,
     claimAttempts = 1,
   )
+
   @Test
   fun `findByClaimAttemptsIs returns only unclaimed SAR entries if called with 0`() {
     val expectedAll: List<SubjectAccessRequest> = listOf(sampleClaimedSAR, sampleUnclaimedSAR)
@@ -66,6 +67,7 @@ class SubjectAccessRequestRepositoryTest {
     Assertions.assertThat(sarRepository?.findAll()).isEqualTo(expectedAll)
     Assertions.assertThat(sarRepository?.findByClaimAttemptsIs(1)).isEqualTo(expectedClaimed)
   }
+
   @Test
   fun `db doesn't save between tests`() {
     val emptyList: List<Any> = emptyList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -28,7 +28,6 @@ class SubjectAccessRequestRepositoryTest {
   private val ClaimDateTime = "02/01/2024 00:00"
   private val ClaimDateTimeFormatted = LocalDateTime.parse(ClaimDateTime, dateTimeFormatter)
 
-
   val unclaimedSar = SubjectAccessRequest(
     id = null,
     status = Status.Pending,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -16,7 +16,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class SubjectAccessRequestServiceTest{
+class SubjectAccessRequestServiceTest {
 
   private val ndeliusRequest = "{ " +
     "dateFrom: '01/12/2023', " +
@@ -67,6 +67,7 @@ class SubjectAccessRequestServiceTest{
   )
   private val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
   private val authentication: Authentication = Mockito.mock(Authentication::class.java)
+
   @Test
   fun `createSubjectAccessRequestPost and returns 200`() {
     Mockito.`when`(authentication.name).thenReturn("aName")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
+
+class SubjectAccessRequestServiceTest {
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -69,32 +69,32 @@ class SubjectAccessRequestServiceTest {
   private val authentication: Authentication = Mockito.mock(Authentication::class.java)
 
   @Test
-  fun `createSubjectAccessRequestPost and returns 200`() {
+  fun `createSubjectAccessRequestPost and returns empty string`() {
     Mockito.`when`(authentication.name).thenReturn("aName")
-    val expected = ResponseEntity("", HttpStatus.OK)
-    val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
+    val expected = ""
+    val result: String = SubjectAccessRequestService(sarGateway)
       .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
     verify(sarGateway, times(1)).saveSubjectAccessRequest(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
   @Test
-  fun `createSubjectAccessRequestPost returns 400 and error string if both IDs are supplied`() {
+  fun `createSubjectAccessRequestPost returns error string if both IDs are supplied`() {
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected =
-      ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
+      "Both nomisId and ndeliusId are provided - exactly one is required"
+    val result: String = SubjectAccessRequestService(sarGateway)
       .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
     verify(sarGateway, times(0)).saveSubjectAccessRequest(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
   @Test
-  fun `createSubjectAccessRequestPost returns 400 and error string if neither ID is supplied`() {
+  fun `createSubjectAccessRequestPost returns error string if neither ID is supplied`() {
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected =
-      ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
+      "Neither nomisId nor ndeliusId is provided - exactly one is required"
+    val result: String = SubjectAccessRequestService(sarGateway)
       .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
     verify(sarGateway, times(0)).saveSubjectAccessRequest(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
 import org.assertj.core.api.Assertions
 import org.json.JSONObject
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -14,13 +12,9 @@ import org.springframework.security.core.Authentication
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.AuditService
-import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.SubjectAccessRequestService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-
 
 class SubjectAccessRequestServiceTest{
 
@@ -71,27 +65,10 @@ class SubjectAccessRequestServiceTest{
     requestDateTime = requestTime,
     claimAttempts = 0,
   )
-
-  private val sampleUnclaimedSAR = SubjectAccessRequest(
-    id = null,
-    status = Status.Pending,
-    dateFrom = dateFromFormatted,
-    dateTo = dateToFormatted,
-    sarCaseReferenceNumber = "1234abc",
-    services = "{1,2,4}",
-    nomisId = "",
-    ndeliusCaseReferenceId = "1",
-    requestedBy = "Test",
-    requestDateTime = requestTime,
-    claimAttempts = 0,
-  )
-
+  private val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
+  private val authentication: Authentication = Mockito.mock(Authentication::class.java)
   @Test
   fun `createSubjectAccessRequestPost and returns 200`() {
-    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
-    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
-    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
-    val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected = ResponseEntity("", HttpStatus.OK)
     val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
@@ -102,11 +79,6 @@ class SubjectAccessRequestServiceTest{
 
   @Test
   fun `createSubjectAccessRequestPost returns 400 and error string if both IDs are supplied`() {
-    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
-    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
-    val auditService = Mockito.mock(AuditService::class.java)
-    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
-    val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected =
       ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
@@ -118,11 +90,6 @@ class SubjectAccessRequestServiceTest{
 
   @Test
   fun `createSubjectAccessRequestPost returns 400 and error string if neither ID is supplied`() {
-    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
-    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
-    val auditService = Mockito.mock(AuditService::class.java)
-    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
-    val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected =
       ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -1,4 +1,131 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services
 
-class SubjectAccessRequestServiceTest {
+import org.assertj.core.api.Assertions
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.AuditService
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.services.SubjectAccessRequestService
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+
+class SubjectAccessRequestServiceTest{
+
+  private val ndeliusRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '', " +
+    "ndeliusId: '1' " +
+    "}"
+
+  private val ndeliusAndNomisRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '1', " +
+    "ndeliusId: '1' " +
+    "}"
+
+  private val noIDRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '', " +
+    "ndeliusId: '' " +
+    "}"
+
+  private val json = JSONObject(ndeliusRequest)
+  private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  private val dateFrom = json.get("dateFrom").toString()
+  private val dateFromFormatted = LocalDate.parse(dateFrom, formatter)
+  private val dateTo = json.get("dateTo").toString()
+  private val dateToFormatted = LocalDate.parse(dateTo, formatter)
+  private val requestTime = LocalDateTime.now()
+  private val sampleSAR = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "aName",
+    requestDateTime = requestTime,
+    claimAttempts = 0,
+  )
+
+  private val sampleUnclaimedSAR = SubjectAccessRequest(
+    id = null,
+    status = Status.Pending,
+    dateFrom = dateFromFormatted,
+    dateTo = dateToFormatted,
+    sarCaseReferenceNumber = "1234abc",
+    services = "{1,2,4}",
+    nomisId = "",
+    ndeliusCaseReferenceId = "1",
+    requestedBy = "Test",
+    requestDateTime = requestTime,
+    claimAttempts = 0,
+  )
+
+  @Test
+  fun `createSubjectAccessRequestPost and returns 200`() {
+    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
+    val auditService = Mockito.mock(AuditService::class.java)
+    val authentication: Authentication = Mockito.mock(Authentication::class.java)
+    Mockito.`when`(authentication.name).thenReturn("aName")
+    val expected = ResponseEntity("", HttpStatus.OK)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
+      .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
+    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
+    Assertions.assertThat(result).isEqualTo(expected)
+  }
+
+  @Test
+  fun `createSubjectAccessRequestPost returns 400 and error string if both IDs are supplied`() {
+    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val auditService = Mockito.mock(AuditService::class.java)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
+    val authentication: Authentication = Mockito.mock(Authentication::class.java)
+    Mockito.`when`(authentication.name).thenReturn("aName")
+    val expected =
+      ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
+      .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
+    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
+    Assertions.assertThat(result).isEqualTo(expected)
+  }
+
+  @Test
+  fun `createSubjectAccessRequestPost returns 400 and error string if neither ID is supplied`() {
+    val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val auditService = Mockito.mock(AuditService::class.java)
+    val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
+    val authentication: Authentication = Mockito.mock(Authentication::class.java)
+    Mockito.`when`(authentication.name).thenReturn("aName")
+    val expected =
+      ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)
+    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
+      .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
+    verify(sarService, times(1)).createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
+    Assertions.assertThat(result).isEqualTo(expected)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mockito.verify
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
@@ -87,45 +88,47 @@ class SubjectAccessRequestServiceTest{
 
   @Test
   fun `createSubjectAccessRequestPost and returns 200`() {
+    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
     val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
-    val auditService = Mockito.mock(AuditService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected = ResponseEntity("", HttpStatus.OK)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
+    val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
       .createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
-    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusRequest, authentication, requestTime)
+    verify(sarGateway, times(1)).saveSubjectAccessRequest(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
   @Test
   fun `createSubjectAccessRequestPost returns 400 and error string if both IDs are supplied`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
     val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected =
       ResponseEntity("Both nomisId and ndeliusId are provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
+    val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
       .createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
-    verify(sarService, times(1)).createSubjectAccessRequestPost(ndeliusAndNomisRequest, authentication, requestTime)
+    verify(sarGateway, times(0)).saveSubjectAccessRequest(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 
   @Test
   fun `createSubjectAccessRequestPost returns 400 and error string if neither ID is supplied`() {
     val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
+    val sarGateway = Mockito.mock(SubjectAccessRequestGateway::class.java)
     val auditService = Mockito.mock(AuditService::class.java)
     val sarService = Mockito.mock(SubjectAccessRequestService::class.java)
     val authentication: Authentication = Mockito.mock(Authentication::class.java)
     Mockito.`when`(authentication.name).thenReturn("aName")
     val expected =
       ResponseEntity("Neither nomisId nor ndeliusId is provided - exactly one is required", HttpStatus.BAD_REQUEST)
-    val result: ResponseEntity<String> = SubjectAccessRequestController(sarService, auditService)
+    val result: ResponseEntity<String> = SubjectAccessRequestService(sarGateway)
       .createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
-    verify(sarService, times(1)).createSubjectAccessRequestPost(noIDRequest, authentication, requestTime)
+    verify(sarGateway, times(0)).saveSubjectAccessRequest(sampleSAR)
     Assertions.assertThat(result).isEqualTo(expected)
   }
 }


### PR DESCRIPTION
This is a PR for adding the claim endpoint to the backend. This endpoint will retrieve all unclaimed SAR requests from the database if 'unclaimed' is specified in the endpoint call.
A second endpoint will be added in a separate PR to patch the claimAttempts and claimDateTime once the claim has been made by the worker.
This PR also includes restructuring the repository to use the controller - service - gateway- repository architecture.