### PR TITLE
Update requestedBy to use ID sent in request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -90,11 +90,13 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
   @Parameter(name = "dateTo", description = "End date of the period of time the requested SAR report must cover.", required = true, example = "31/12/2000")
   @Parameter(name = "sarCaseReferenceNumber", description = "Case reference number of the Subject Access Request.", required = true, example = "exampleCaseReferenceNumber")
   @Parameter(name = "services", description = "List of services from which subject data must be retrieved.", required = true, example = "[\"service1, service1.prison.service.justice.gov.uk\"]")
+  @Parameter(name = "requestedBy", description = "ID of the user that requested the SAR report.", required = true, example = "exampleUUID")
   fun createSubjectAccessRequest(@RequestBody request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
     log.info("Creating SAR Request")
     val json = JSONObject(request)
     val nomisId = json.get("nomisId").toString()
     val ndeliusId = json.get("ndeliusId").toString()
+    val requestedBy = json.get("requestedBy").toString()
     telemetryClient.trackEvent(
       "createSubjectAccessRequest",
       mapOf(
@@ -104,7 +106,7 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
       ),
     )
     val auditDetails = Json.encodeToString(AuditDetails(nomisId, ndeliusId))
-    auditService.createEvent(authentication.name, "CREATE_SUBJECT_ACCESS_REQUEST", auditDetails)
+    auditService.createEvent(requestedBy, "CREATE_SUBJECT_ACCESS_REQUEST", auditDetails)
     val response = subjectAccessRequestService.createSubjectAccessRequest(
       request = request,
       authentication = authentication,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -47,7 +47,7 @@ class SubjectAccessRequestService(
         services = json.get("services").toString(),
         nomisId = json.get("nomisId").toString(),
         ndeliusCaseReferenceId = json.get("ndeliusId").toString(),
-        requestedBy = authentication.name,
+        requestedBy = json.get("requestedBy").toString(),
         requestDateTime = requestTime ?: LocalDateTime.now(),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -33,9 +33,9 @@ class SubjectAccessRequestControllerTest {
       "sarCaseReferenceNumber: '1234abc', " +
       "services: '{1,2,4}', " +
       "nomisId: '', " +
-      "ndeliusId: '1' " +
+      "ndeliusId: '1', " +
+      "requestedBy: 'mockUserId' " +
       "}"
-    Mockito.`when`(authentication.name).thenReturn("aName")
     Mockito.`when`(sarService.createSubjectAccessRequest(ndeliusRequest, authentication, requestTime)).thenReturn("")
     val result = SubjectAccessRequestController(sarService, auditService, telemetryClient)
       .createSubjectAccessRequest(ndeliusRequest, authentication, requestTime)
@@ -53,7 +53,8 @@ class SubjectAccessRequestControllerTest {
       "sarCaseReferenceNumber: '1234abc', " +
       "services: '{1,2,4}', " +
       "nomisId: '1', " +
-      "ndeliusId: '1' " +
+      "ndeliusId: '1', " +
+      "requestedBy: 'mockUserId' " +
       "}"
     Mockito.`when`(sarService.createSubjectAccessRequest(ndeliusAndNomisRequest, authentication, requestTime)).thenReturn("Both nomisId and ndeliusId are provided - exactly one is required")
     val response = SubjectAccessRequestController(sarService, auditService, telemetryClient)
@@ -72,7 +73,8 @@ class SubjectAccessRequestControllerTest {
       "sarCaseReferenceNumber: '1234abc', " +
       "services: '{1,2,4}', " +
       "nomisId: '', " +
-      "ndeliusId: '' " +
+      "ndeliusId: '', " +
+      "requestedBy: 'mockUserId' " +
       "}"
     Mockito.`when`(sarService.createSubjectAccessRequest(noIDRequest, authentication, requestTime)).thenReturn("Neither nomisId nor ndeliusId is provided - exactly one is required")
     val response = SubjectAccessRequestController(sarService, auditService, telemetryClient)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -25,7 +25,8 @@ class SubjectAccessRequestServiceTest {
     "sarCaseReferenceNumber: '1234abc', " +
     "services: '{1,2,4}', " +
     "nomisId: '', " +
-    "ndeliusId: '1' " +
+    "ndeliusId: '1', " +
+    "requestedBy: 'mockUserId' " +
     "}"
 
   private val ndeliusAndNomisRequest = "{ " +
@@ -34,7 +35,8 @@ class SubjectAccessRequestServiceTest {
     "sarCaseReferenceNumber: '1234abc', " +
     "services: '{1,2,4}', " +
     "nomisId: '1', " +
-    "ndeliusId: '1' " +
+    "ndeliusId: '1', " +
+    "requestedBy: 'mockUserId' " +
     "}"
 
   private val noIDRequest = "{ " +
@@ -43,7 +45,8 @@ class SubjectAccessRequestServiceTest {
     "sarCaseReferenceNumber: '1234abc', " +
     "services: '{1,2,4}', " +
     "nomisId: '', " +
-    "ndeliusId: '' " +
+    "ndeliusId: '', " +
+    "requestedBy: 'mockUserId' " +
     "}"
 
   private val json = JSONObject(ndeliusRequest)
@@ -62,7 +65,7 @@ class SubjectAccessRequestServiceTest {
     services = "{1,2,4}",
     nomisId = "",
     ndeliusCaseReferenceId = "1",
-    requestedBy = "aName",
+    requestedBy = "mockUserId",
     requestDateTime = requestTime,
     claimAttempts = 0,
   )
@@ -73,8 +76,7 @@ class SubjectAccessRequestServiceTest {
   @Nested
   inner class createSubjectAccessRequest {
     @Test
-    fun `createSubjectAccessRequest and returns empty string`() {
-      Mockito.`when`(authentication.name).thenReturn("aName")
+    fun `createSubjectAccessRequest returns empty string`() {
       val expected = ""
       val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
         .createSubjectAccessRequest(ndeliusRequest, authentication, requestTime, sampleSAR.id)
@@ -84,7 +86,6 @@ class SubjectAccessRequestServiceTest {
 
     @Test
     fun `createSubjectAccessRequest returns error string if both IDs are supplied`() {
-      Mockito.`when`(authentication.name).thenReturn("aName")
       val expected =
         "Both nomisId and ndeliusId are provided - exactly one is required"
       val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
@@ -95,7 +96,6 @@ class SubjectAccessRequestServiceTest {
 
     @Test
     fun `createSubjectAccessRequest returns error string if neither subject ID is supplied`() {
-      Mockito.`when`(authentication.name).thenReturn("aName")
       val expected =
         "Neither nomisId nor ndeliusId is provided - exactly one is required"
       val result: String = SubjectAccessRequestService(sarGateway, documentGateway)


### PR DESCRIPTION
## Context
The SAR database's RequestedBy field and the message we send to the audit service currently lists the SAR Frontend as the person carrying out actions on the API. We need the audit service to have the actual username of the person interacting with the system.

This PR is the second half of [SR131](https://dsdmoj.atlassian.net/browse/SR-131). The first half is [PR39 in the SAR UI repo](https://github.com/ministryofjustice/hmpps-subject-access-request-ui/pull/39), which extracts the user's ID from their auth token stored as part of the session data.

## Changes proposed in this PR
This PR updates the requestedBy field of a SAR request to use the requestedBy value now sent by the UI, which corresponds with the requestor's ID. The "who" field sent to the Audit service is also updated with the new requestedBy value.