### PR TITLE
Fix bug where blank dateTo errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -90,8 +90,8 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
   )
   @Parameter(name = "nomisId", description = "Subject's NOMIS prisoner number. Either nomisId OR ndeliusId is required.", required = false, example = "A1234BC")
   @Parameter(name = "ndeliusId", description = "Subject's nDelius case reference number. Either nomisId OR ndeliusId is required.", required = false, example = "A123456")
-  @Parameter(name = "dateFrom", description = "Start date of the period of time the requested SAR report must cover.", required = true, example = "31/12/1999")
-  @Parameter(name = "dateTo", description = "End date of the period of time the requested SAR report must cover.", required = true, example = "31/12/2000")
+  @Parameter(name = "dateFrom", description = "Start date of the period of time the requested SAR report must cover.", required = false, example = "31/12/1999")
+  @Parameter(name = "dateTo", description = "End date of the period of time the requested SAR report must cover.", required = false, example = "31/12/2000")
   @Parameter(name = "sarCaseReferenceNumber", description = "Case reference number of the Subject Access Request.", required = true, example = "exampleCaseReferenceNumber")
   @Parameter(name = "services", description = "List of services from which subject data must be retrieved.", required = true, example = "[\"service1, service1.prison.service.justice.gov.uk\"]")
   fun createSubjectAccessRequest(@RequestBody request: String, authentication: Authentication, requestTime: LocalDateTime?): ResponseEntity<String> {
@@ -99,7 +99,6 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
     val json = JSONObject(request)
     val nomisId = json.get("nomisId").toString()
     val ndeliusId = json.get("ndeliusId").toString()
-    val requestedBy = authentication.name
     telemetryClient.trackEvent(
       "createSubjectAccessRequest",
       mapOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -29,11 +29,8 @@ class SubjectAccessRequestService(
     id: UUID? = null,
   ): String {
     val json = JSONObject(request)
-    val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-    val dateFrom = json.get("dateFrom").toString()
-    val dateFromFormatted = if (dateFrom != "") LocalDate.parse(dateFrom, formatter) else null
-    val dateTo = json.get("dateTo").toString()
-    val dateToFormatted = LocalDate.parse(dateTo, formatter)
+    val dateFrom = formatDate(json.get("dateFrom").toString())
+    val dateTo = formatDate(json.get("dateTo").toString())
 
     if (json.get("nomisId") != "" && json.get("ndeliusId") != "") {
       return "Both nomisId and ndeliusId are provided - exactly one is required"
@@ -44,8 +41,8 @@ class SubjectAccessRequestService(
       SubjectAccessRequest(
         id = id ?: UUID.randomUUID(),
         status = Status.Pending,
-        dateFrom = dateFromFormatted,
-        dateTo = dateToFormatted,
+        dateFrom = dateFrom,
+        dateTo = dateTo,
         sarCaseReferenceNumber = json.get("sarCaseReferenceNumber").toString(),
         services = json.get("services").toString(),
         nomisId = json.get("nomisId").toString(),
@@ -102,6 +99,15 @@ class SubjectAccessRequestService(
     } catch (e: NullPointerException) {
       return emptyList()
     }
+  }
+}
+
+private fun formatDate(date: String): LocalDate? {
+  val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  return if (date != "") {
+    LocalDate.parse(date, formatter)
+  } else {
+    null
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -50,6 +50,24 @@ class SubjectAccessRequestServiceTest {
     "ndeliusId: '' " +
     "}"
 
+  private val noDateToRequest = "{ " +
+    "dateFrom: '01/12/2023', " +
+    "dateTo: '', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '', " +
+    "ndeliusId: '1' " +
+    "}"
+
+  private val noDateFromRequest = "{ " +
+    "dateFrom: '', " +
+    "dateTo: '03/01/2024', " +
+    "sarCaseReferenceNumber: '1234abc', " +
+    "services: '{1,2,4}', " +
+    "nomisId: '', " +
+    "ndeliusId: '1' " +
+    "}"
+
   private val json = JSONObject(ndeliusRequest)
   private val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
   private val dateFrom = json.get("dateFrom").toString()
@@ -79,10 +97,11 @@ class SubjectAccessRequestServiceTest {
     @Test
     fun `createSubjectAccessRequest returns empty string`() {
       Mockito.`when`(authentication.name).thenReturn("mockUserName")
-
       val expected = ""
+
       val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
         .createSubjectAccessRequest(ndeliusRequest, authentication, requestTime, sampleSAR.id)
+
       verify(sarGateway, times(1)).saveSubjectAccessRequest(sampleSAR)
       Assertions.assertThat(result).isEqualTo(expected)
     }
@@ -91,8 +110,10 @@ class SubjectAccessRequestServiceTest {
     fun `createSubjectAccessRequest returns error string if both IDs are supplied`() {
       val expected =
         "Both nomisId and ndeliusId are provided - exactly one is required"
+
       val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
         .createSubjectAccessRequest(ndeliusAndNomisRequest, authentication, requestTime, sampleSAR.id)
+
       verify(sarGateway, times(0)).saveSubjectAccessRequest(sampleSAR)
       Assertions.assertThat(result).isEqualTo(expected)
     }
@@ -101,9 +122,35 @@ class SubjectAccessRequestServiceTest {
     fun `createSubjectAccessRequest returns error string if neither subject ID is supplied`() {
       val expected =
         "Neither nomisId nor ndeliusId is provided - exactly one is required"
+
       val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
         .createSubjectAccessRequest(noIDRequest, authentication, requestTime, sampleSAR.id)
+
       verify(sarGateway, times(0)).saveSubjectAccessRequest(sampleSAR)
+      Assertions.assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `createSubjectAccessRequest does not error when dateTo is not provided`() {
+      Mockito.`when`(authentication.name).thenReturn("mockUserName")
+      val expected = ""
+
+      val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
+        .createSubjectAccessRequest(noDateToRequest, authentication, requestTime, sampleSAR.id)
+
+      verify(sarGateway, times(1)).saveSubjectAccessRequest(any())
+      Assertions.assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `createSubjectAccessRequest does not error when dateFrom is not provided`() {
+      Mockito.`when`(authentication.name).thenReturn("mockUserName")
+      val expected = ""
+
+      val result: String = SubjectAccessRequestService(sarGateway, documentGateway)
+        .createSubjectAccessRequest(noDateFromRequest, authentication, requestTime, sampleSAR.id)
+
+      verify(sarGateway, times(1)).saveSubjectAccessRequest(any())
       Assertions.assertThat(result).isEqualTo(expected)
     }
   }


### PR DESCRIPTION
## Context
- An error occurs in the UI when a user tries to submit a SAR report request with a blank dateTo field.

<img width="948" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-api/assets/95350189/9ab1992d-f710-4211-af43-c6135b68a489">

## Changes proposed in this PR
- This PR fixes the bug and adds tests for this case.


