### PR TITLE
Add todays date to dateTo when null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -24,6 +25,7 @@ class SubjectAccessRequestGateway(@Autowired val repo: SubjectAccessRequestRepos
   }
 
   fun saveSubjectAccessRequest(sar: SubjectAccessRequest) {
+    if (sar.dateTo == null) { sar.dateTo = LocalDate.now() }
     repo.save(sar)
   }
   fun updateSubjectAccessRequestClaim(id: UUID, thresholdTime: LocalDateTime, currentTime: LocalDateTime): Int {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/models/SubjectAccessRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/models/SubjectAccessRequest.kt
@@ -20,7 +20,7 @@ data class SubjectAccessRequest(
   @Enumerated(EnumType.STRING)
   val status: Status = Status.Pending,
   val dateFrom: LocalDate? = null,
-  val dateTo: LocalDate? = null,
+  var dateTo: LocalDate? = null,
   val sarCaseReferenceNumber: String = "",
   val services: String = "",
   val nomisId: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -44,6 +44,45 @@ class SubjectAccessRequestGatewayTest {
   private val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
 
   @Nested
+  inner class saveSubjectAccessRequest {
+    @Test
+    fun `saves SAR with dateTo of today when dateTo is null`() {
+      val sarWithNoDateTo = SubjectAccessRequest(
+        id = testUuid,
+        status = Status.Pending,
+        dateFrom = dateFromFormatted,
+        dateTo = null,
+        sarCaseReferenceNumber = "1234abc",
+        services = "{1,2,4}",
+        nomisId = "",
+        ndeliusCaseReferenceId = "1",
+        requestedBy = "Test",
+        requestDateTime = requestTimeFormatted,
+        claimAttempts = 0,
+      )
+
+      SubjectAccessRequestGateway(sarRepository)
+        .saveSubjectAccessRequest(sarWithNoDateTo)
+      verify(sarRepository, times(1)).save(
+        SubjectAccessRequest(
+          id = testUuid,
+          status = Status.Pending,
+          dateFrom = dateFromFormatted,
+          dateTo = LocalDate.now(),
+          sarCaseReferenceNumber = "1234abc",
+          services = "{1,2,4}",
+          nomisId = "",
+          ndeliusCaseReferenceId = "1",
+          requestedBy = "Test",
+          requestDateTime = requestTimeFormatted,
+          claimAttempts = 0,
+        ),
+
+      )
+    }
+  }
+
+  @Nested
   inner class getSubjectAccessRequests {
 
     @Test


### PR DESCRIPTION
## Context
- The service has a bug where, when a user creates a SAR report request via the UI, if the dateTo field is empty, an error occurs. 

## Changes proposed in this PR
- Add todays date to dateTo when null so that the SAR report can be saved to the database.