### PR TITLE
Fix pagination bug where results are returned in ascending request date order

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -14,7 +14,6 @@ import kotlinx.serialization.json.Json
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -429,8 +428,8 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
   }
 
   @GetMapping("reports")
-  fun getSubjectAccessRequestReports(@RequestParam(required = true, name = "pageSize") pageSize: Int, @RequestParam(required = true, name = "pageNumber") pageNumber: Int): List<SubjectAccessRequestReport> {
-    val response = subjectAccessRequestService.getAllReports(PageRequest.of(pageNumber, pageSize))
+  fun getSubjectAccessRequestReports(@RequestParam(required = true, name = "pageNumber") pageNumber: Int, @RequestParam(required = true, name = "pageSize") pageSize: Int): List<SubjectAccessRequestReport> {
+    val response = subjectAccessRequestService.getAllReports(pageNumber, pageSize)
     return response
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
@@ -38,8 +39,8 @@ class SubjectAccessRequestGateway(@Autowired val repo: SubjectAccessRequestRepos
     return result
   }
 
-  fun getAllReports(pagination: PageRequest): Page<SubjectAccessRequest?> {
-    val reports = repo.findAll(pagination)
+  fun getAllReports(pageNumber: Int, pageSize: Int): Page<SubjectAccessRequest?> {
+    val reports = repo.findAll(PageRequest.of(pageNumber, pageSize, Sort.by("RequestDateTime").descending()))
     try {
       reports.content
       return reports

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.Serializable
 import org.json.JSONObject
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.io.InputStreamResource
-import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
@@ -83,8 +82,8 @@ class SubjectAccessRequestService(
     return document
   }
 
-  fun getAllReports(pagination: PageRequest): List<SubjectAccessRequestReport> {
-    val reports = sarDbGateway.getAllReports(pagination)
+  fun getAllReports(pageNumber: Int, pageSize: Int): List<SubjectAccessRequestReport> {
+    val reports = sarDbGateway.getAllReports(pageNumber, pageSize)
     try {
       val reportInfo = reports.content
       val condensedReportInfo = emptyList<SubjectAccessRequestReport>().toMutableList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -10,7 +10,6 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.eq
 import org.springframework.core.io.InputStreamResource
-import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -203,7 +202,7 @@ class SubjectAccessRequestControllerTest {
     fun `getSubjectAccessRequestReports is called with pagination parameters`() {
       SubjectAccessRequestController(sarService, auditService, telemetryClient)
         .getSubjectAccessRequestReports(1, 1)
-      verify(sarService, times(1)).getAllReports(PageRequest.of(1, 1))
+      verify(sarService, times(1)).getAllReports(1, 1)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.repository.SubjectAccessRequestRepository
@@ -17,8 +18,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 class SubjectAccessRequestGatewayTest {
-
-  val testUuid = UUID.fromString("55555555-5555-5555-5555-555555555555")
+  private val testUuid = UUID.fromString("11111111-1111-1111-1111-111111111111")
   private val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
   private val dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
   private val dateFrom = "01/12/2023"
@@ -27,6 +27,7 @@ class SubjectAccessRequestGatewayTest {
   private val dateToFormatted = LocalDate.parse(dateTo, dateFormatter)
   private val requestTime = "01/01/2024 00:00"
   private val requestTimeFormatted = LocalDateTime.parse(requestTime, dateTimeFormatter)
+
   private val unclaimedSar = SubjectAccessRequest(
     id = testUuid,
     status = Status.Pending,
@@ -40,6 +41,7 @@ class SubjectAccessRequestGatewayTest {
     requestDateTime = requestTimeFormatted,
     claimAttempts = 0,
   )
+
   private val mockSarsWithNoClaims = listOf(unclaimedSar, unclaimedSar, unclaimedSar)
   private val sarRepository = Mockito.mock(SubjectAccessRequestRepository::class.java)
 
@@ -161,10 +163,12 @@ class SubjectAccessRequestGatewayTest {
   @Nested
   inner class getAllReports {
     @Test
-    fun `getReports calls repository findAll method with pagination`() {
+    fun `getReports calls repository findAll method with requestDateTime-sorted pagination`() {
       Mockito.`when`(sarRepository.findAll(PageRequest.of(0, 1))).thenReturn(any())
-      SubjectAccessRequestGateway(sarRepository).getAllReports(PageRequest.of(0, 1))
-      verify(sarRepository, times(1)).findAll(PageRequest.of(0, 1))
+
+      SubjectAccessRequestGateway(sarRepository).getAllReports(0, 1)
+
+      verify(sarRepository, times(1)).findAll(PageRequest.of(0, 1,  Sort.by("RequestDateTime").descending()))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -79,14 +79,12 @@ class SubjectAccessRequestGatewayTest {
           requestDateTime = requestTimeFormatted,
           claimAttempts = 0,
         ),
-
       )
     }
   }
 
   @Nested
   inner class getSubjectAccessRequests {
-
     @Test
     fun `calls findAll if unclaimed is false`() {
       SubjectAccessRequestGateway(sarRepository)
@@ -168,7 +166,7 @@ class SubjectAccessRequestGatewayTest {
 
       SubjectAccessRequestGateway(sarRepository).getAllReports(0, 1)
 
-      verify(sarRepository, times(1)).findAll(PageRequest.of(0, 1,  Sort.by("RequestDateTime").descending()))
+      verify(sarRepository, times(1)).findAll(PageRequest.of(0, 1, Sort.by("RequestDateTime").descending()))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -9,7 +9,6 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.springframework.core.io.InputStreamResource
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -9,8 +9,8 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.springframework.core.io.InputStreamResource
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import reactor.core.publisher.Flux
@@ -222,14 +222,16 @@ class SubjectAccessRequestServiceTest {
   inner class getAllReports {
     @Test
     fun `getAllReports calls SAR gateway getAllReports method with pagination`() {
-      Mockito.`when`(sarGateway.getAllReports(PageRequest.of(0, 1))).thenReturn(any())
-      SubjectAccessRequestService(sarGateway, documentGateway).getAllReports(PageRequest.of(0, 1))
-      verify(sarGateway, times(1)).getAllReports(PageRequest.of(0, 1))
+      Mockito.`when`(sarGateway.getAllReports(0, 1)).thenReturn(PageImpl(listOf(sampleSAR)))
+
+      SubjectAccessRequestService(sarGateway, documentGateway).getAllReports(0, 1)
+
+      verify(sarGateway, times(1)).getAllReports(0, 1)
     }
 
     @Test
     fun `getAllReports extracts condensed report info`() {
-      Mockito.`when`(sarGateway.getAllReports(PageRequest.of(0, 1))).thenReturn(PageImpl(listOf(sampleSAR)))
+      Mockito.`when`(sarGateway.getAllReports(0, 1)).thenReturn(PageImpl(listOf(sampleSAR)))
       val expectedResult =
         SubjectAccessRequestReport(
           uuid = "11111111-1111-1111-1111-111111111111",
@@ -238,7 +240,7 @@ class SubjectAccessRequestServiceTest {
           subjectId = "1",
           status = "Pending",
         )
-      val result = SubjectAccessRequestService(sarGateway, documentGateway).getAllReports(PageRequest.of(0, 1))
+      val result = SubjectAccessRequestService(sarGateway, documentGateway).getAllReports(0, 1)
       Assertions.assertThat(result[0].dateOfRequest).isEqualTo(sampleSAR.requestDateTime.toString())
       Assertions.assertThat(result[0].toString()).isEqualTo(expectedResult.toString())
     }


### PR DESCRIPTION
## Context

The getReports endpoint, used by our UI to fetch paginated SAR report requests for the View Reports page, is paginating on SAR data that is sorted in ascending order of request date. This means that page 1 of the View Reports page, for example, will be populated with the oldest SAR report requests; users, thus, must navigate to the last page to see the most current and so relevant requests.

## Changes proposed in this PR

This PR sorts the SAR data at the repository/data level, and returns pages accordingly.