### PR TITLE
implement filters for case reference number and subject id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -204,10 +204,10 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
     example = "false",
   )
   @Parameter(
-    name = "filters",
-    description = "Optional URL-encoded JSON string containing filter information to return only data that substring matches all provided filters. Current supported filters: sarCaseReferenceNumber, subjectId.",
+    name = "search",
+    description = "If provided, only results containing this string in the case reference number or subject ID will be returned.",
     required = false,
-    example = "{\"sarCaseReferenceNumber\":\"TEST_REF\",\"subjectId\":\"A1234AA\"}",
+    example = "A1234AA",
   )
   fun getSubjectAccessRequests(
     @RequestParam(
@@ -216,10 +216,10 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
     ) unclaimed: Boolean = false,
     @RequestParam(
       required = false,
-      name = "filters",
-    ) filters: String = "",
+      name = "search",
+    ) search: String = "",
   ): List<SubjectAccessRequest?> {
-    val response = subjectAccessRequestService.getSubjectAccessRequests(unclaimed, filters)
+    val response = subjectAccessRequestService.getSubjectAccessRequests(unclaimed, search)
     return response
   }
 
@@ -263,18 +263,18 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
     ],
   )
   @Parameter(
-    name = "filters",
-    description = "Optional JSON string containing filter information to return only data exactly matching those filters. Current supported filters: caseReference, subjectId.",
+    name = "search",
+    description = "If provided, only results containing this string in the case reference number or subject ID will be returned.",
     required = false,
-    example = "{\"caseReference\":\"TEST_REF\"}",
+    example = "A1234AA",
   )
   fun getTotalSubjectAccessRequests(
     @RequestParam(
       required = false,
-      name = "filters",
-    ) filters: String = "",
+      name = "search",
+    ) search: String = "",
   ): Int {
-    val response = subjectAccessRequestService.getSubjectAccessRequests(false, filters)
+    val response = subjectAccessRequestService.getSubjectAccessRequests(false, search)
     return response.size
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -203,13 +203,23 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
     required = false,
     example = "false",
   )
+  @Parameter(
+    name = "filters",
+    description = "Optional URL-encoded JSON string containing filter information to return only data that substring matches all provided filters. Current supported filters: sarCaseReferenceNumber, subjectId.",
+    required = false,
+    example = "{\"sarCaseReferenceNumber\":\"TEST_REF\",\"subjectId\":\"A1234AA\"}",
+  )
   fun getSubjectAccessRequests(
     @RequestParam(
       required = false,
       name = "unclaimed",
     ) unclaimed: Boolean = false,
+    @RequestParam(
+      required = false,
+      name = "filters",
+    ) filters: String = "",
   ): List<SubjectAccessRequest?> {
-    val response = subjectAccessRequestService.getSubjectAccessRequests(unclaimed)
+    val response = subjectAccessRequestService.getSubjectAccessRequests(unclaimed, filters)
     return response
   }
 
@@ -252,8 +262,19 @@ class SubjectAccessRequestController(@Autowired val subjectAccessRequestService:
       ),
     ],
   )
-  fun getTotalSubjectAccessRequests(): Int {
-    val response = subjectAccessRequestService.getSubjectAccessRequests(false)
+  @Parameter(
+    name = "filters",
+    description = "Optional JSON string containing filter information to return only data exactly matching those filters. Current supported filters: caseReference, subjectId.",
+    required = false,
+    example = "{\"caseReference\":\"TEST_REF\"}",
+  )
+  fun getTotalSubjectAccessRequests(
+    @RequestParam(
+      required = false,
+      name = "filters",
+    ) filters: String = "",
+  ): Int {
+    val response = subjectAccessRequestService.getSubjectAccessRequests(false, filters)
     return response.size
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGateway.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestapi.gateways
 
+import org.json.JSONException
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -14,15 +17,27 @@ import java.util.*
 
 @Component
 class SubjectAccessRequestGateway(@Autowired val repo: SubjectAccessRequestRepository) {
-  fun getSubjectAccessRequests(unclaimedOnly: Boolean, currentTime: LocalDateTime = LocalDateTime.now()): List<SubjectAccessRequest?> {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getSubjectAccessRequests(unclaimedOnly: Boolean, filters: String, currentTime: LocalDateTime = LocalDateTime.now()): List<SubjectAccessRequest?> {
     if (unclaimedOnly) {
       val sarsWithNoClaims = repo.findByStatusIsAndClaimAttemptsIs(Status.Pending, 0)
       val sarsWithExpiredClaims = repo.findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, currentTime.minusMinutes(5))
-      val completeList = sarsWithNoClaims.plus(sarsWithExpiredClaims)
-      return completeList
+      val fullUnclaimedList = sarsWithNoClaims.plus(sarsWithExpiredClaims)
+      return fullUnclaimedList
     }
-    val response = repo.findAll()
-    return response
+    if (filters !== "") {
+      var filterObject = JSONObject("{}")
+      try {
+        filterObject = JSONObject(filters)
+      } catch (exception: JSONException) {
+        log.error("Error parsing filters to JSON object: $filters")
+      }
+      val caseReferenceFilter = filterObject.optString("sarCaseReferenceNumber", "")
+      val subjectIdFilter = filterObject.optString("subjectId", "")
+      return repo.findFilteredRecords(caseReferenceFilter, subjectIdFilter)
+    }
+    return repo.findAll()
   }
 
   fun saveSubjectAccessRequest(sar: SubjectAccessRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -18,10 +18,11 @@ interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, U
 
   @Query(
     "SELECT report FROM SubjectAccessRequest report " +
-      "WHERE report.sarCaseReferenceNumber LIKE CONCAT('%', :sarCaseReferenceNumber, '%') " +
-      "AND (report.nomisId LIKE CONCAT('%', :subjectId, '%') OR report.ndeliusCaseReferenceId LIKE CONCAT('%', :subjectId, '%'))",
+      "WHERE report.sarCaseReferenceNumber LIKE CONCAT('%', :search, '%') " +
+      "OR report.nomisId LIKE CONCAT('%', :search, '%') " +
+      "OR report.ndeliusCaseReferenceId LIKE CONCAT('%', :search, '%')",
   )
-  fun findFilteredRecords(sarCaseReferenceNumber: String, subjectId: String): List<SubjectAccessRequest?>
+  fun findFilteredRecords(search: String): List<SubjectAccessRequest?>
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -16,6 +16,13 @@ interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, U
 
   fun findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(status: Status, claimAttempts: Int, claimDateTime: LocalDateTime): List<SubjectAccessRequest?>
 
+  @Query(
+    "SELECT report FROM SubjectAccessRequest report " +
+      "WHERE report.sarCaseReferenceNumber LIKE CONCAT('%', :sarCaseReferenceNumber, '%') " +
+      "AND (report.nomisId LIKE CONCAT('%', :subjectId, '%') OR report.ndeliusCaseReferenceId LIKE CONCAT('%', :subjectId, '%'))",
+  )
+  fun findFilteredRecords(sarCaseReferenceNumber: String, subjectId: String): List<SubjectAccessRequest?>
+
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
     "UPDATE SubjectAccessRequest report " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -67,8 +67,8 @@ class SubjectAccessRequestService(
     return "" // Maybe want to return Report ID?
   }
 
-  fun getSubjectAccessRequests(unclaimedOnly: Boolean): List<SubjectAccessRequest?> {
-    val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly)
+  fun getSubjectAccessRequests(unclaimedOnly: Boolean, filters: String): List<SubjectAccessRequest?> {
+    val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly, filters)
     return subjectAccessRequests
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -67,8 +67,8 @@ class SubjectAccessRequestService(
     return "" // Maybe want to return Report ID?
   }
 
-  fun getSubjectAccessRequests(unclaimedOnly: Boolean, filters: String): List<SubjectAccessRequest?> {
-    val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly, filters)
+  fun getSubjectAccessRequests(unclaimedOnly: Boolean, search: String): List<SubjectAccessRequest?> {
+    val subjectAccessRequests = sarDbGateway.getSubjectAccessRequests(unclaimedOnly, search)
     return subjectAccessRequests
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -103,9 +103,9 @@ class SubjectAccessRequestControllerTest {
     fun `getSubjectAccessRequests is called with unclaimedOnly = true if specified in controller and returns list`() {
       val result: List<SubjectAccessRequest?> =
         SubjectAccessRequestController(sarService, auditService, telemetryClient)
-          .getSubjectAccessRequests(unclaimed = true, filters = "")
+          .getSubjectAccessRequests(unclaimed = true, search = "")
 
-      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = true, filters = "")
+      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = true, search = "")
       Assertions.assertThatList(result)
     }
 
@@ -114,7 +114,7 @@ class SubjectAccessRequestControllerTest {
       SubjectAccessRequestController(sarService, auditService, telemetryClient)
         .getSubjectAccessRequests()
 
-      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false, filters = "")
+      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false, search = "")
     }
   }
 
@@ -124,7 +124,7 @@ class SubjectAccessRequestControllerTest {
     fun `getTotalSubjectAccessRequests calls getSubjectAccessRequests with unclaimedOnly = false `() {
       SubjectAccessRequestController(sarService, auditService, telemetryClient)
         .getTotalSubjectAccessRequests()
-      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false, filters = "")
+      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false, search = "")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/controllers/SubjectAccessRequestControllerTest.kt
@@ -103,9 +103,9 @@ class SubjectAccessRequestControllerTest {
     fun `getSubjectAccessRequests is called with unclaimedOnly = true if specified in controller and returns list`() {
       val result: List<SubjectAccessRequest?> =
         SubjectAccessRequestController(sarService, auditService, telemetryClient)
-          .getSubjectAccessRequests(unclaimed = true)
+          .getSubjectAccessRequests(unclaimed = true, filters = "")
 
-      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = true)
+      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = true, filters = "")
       Assertions.assertThatList(result)
     }
 
@@ -114,7 +114,7 @@ class SubjectAccessRequestControllerTest {
       SubjectAccessRequestController(sarService, auditService, telemetryClient)
         .getSubjectAccessRequests()
 
-      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false)
+      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false, filters = "")
     }
   }
 
@@ -124,7 +124,7 @@ class SubjectAccessRequestControllerTest {
     fun `getTotalSubjectAccessRequests calls getSubjectAccessRequests with unclaimedOnly = false `() {
       SubjectAccessRequestController(sarService, auditService, telemetryClient)
         .getTotalSubjectAccessRequests()
-      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false)
+      verify(sarService, times(1)).getSubjectAccessRequests(unclaimedOnly = false, filters = "")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -88,21 +88,21 @@ class SubjectAccessRequestGatewayTest {
     @Test
     fun `calls findAll if unclaimed is false and no filters are specified`() {
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = false, filters = "")
+        .getSubjectAccessRequests(unclaimedOnly = false, search = "")
       verify(sarRepository, times(1)).findAll()
     }
 
     @Test
     fun `calls findByClaimAttemptsIs if unclaimed is true and no filters are specified`() {
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true, filters = "")
+        .getSubjectAccessRequests(unclaimedOnly = true, search = "")
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsIs(Status.Pending, 0)
     }
 
     @Test
     fun `calls findByClaimAttemptsIs(0) if unclaimed is true and no filters are specified`() {
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true, filters = "")
+        .getSubjectAccessRequests(unclaimedOnly = true, search = "")
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsIs(Status.Pending, 0)
     }
 
@@ -113,7 +113,7 @@ class SubjectAccessRequestGatewayTest {
       val expiredClaimDateTime = "01/01/2024 23:55"
       val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true, filters = "", formattedMockedCurrentTime)
+        .getSubjectAccessRequests(unclaimedOnly = true, search = "", formattedMockedCurrentTime)
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
     }
 
@@ -128,17 +128,17 @@ class SubjectAccessRequestGatewayTest {
         emptyList(),
       )
       val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true, filters = "", formattedMockedCurrentTime)
+        .getSubjectAccessRequests(unclaimedOnly = true, search = "", formattedMockedCurrentTime)
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
       Assertions.assertTrue(result.size == 3)
     }
 
     @Test
     fun `passes correct parameters and returns filtered list if unclaimed is false and filters are provided`() {
-      Mockito.`when`(sarRepository.findFilteredRecords("TEST_REF", "TEST_ID")).thenReturn(mockSarsWithNoClaims)
+      Mockito.`when`(sarRepository.findFilteredRecords("TEST_REF")).thenReturn(mockSarsWithNoClaims)
       val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = false, filters = "{\"sarCaseReferenceNumber\":\"TEST_REF\",\"subjectId\":\"TEST_ID\"}")
-      verify(sarRepository, times(1)).findFilteredRecords(sarCaseReferenceNumber = "TEST_REF", subjectId = "TEST_ID")
+        .getSubjectAccessRequests(unclaimedOnly = false, search = "TEST_REF")
+      verify(sarRepository, times(1)).findFilteredRecords(search = "TEST_REF")
       Assertions.assertTrue(result.size == 3)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestapi/gateways/SubjectAccessRequestGatewayTest.kt
@@ -86,23 +86,23 @@ class SubjectAccessRequestGatewayTest {
   @Nested
   inner class GetSubjectAccessRequests {
     @Test
-    fun `calls findAll if unclaimed is false`() {
+    fun `calls findAll if unclaimed is false and no filters are specified`() {
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = false)
+        .getSubjectAccessRequests(unclaimedOnly = false, filters = "")
       verify(sarRepository, times(1)).findAll()
     }
 
     @Test
-    fun `calls findByClaimAttemptsIs if unclaimed is true`() {
+    fun `calls findByClaimAttemptsIs if unclaimed is true and no filters are specified`() {
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true)
+        .getSubjectAccessRequests(unclaimedOnly = true, filters = "")
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsIs(Status.Pending, 0)
     }
 
     @Test
-    fun `calls findByClaimAttemptsIs(0) if unclaimed is true`() {
+    fun `calls findByClaimAttemptsIs(0) if unclaimed is true and no filters are specified`() {
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true)
+        .getSubjectAccessRequests(unclaimedOnly = true, filters = "")
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsIs(Status.Pending, 0)
     }
 
@@ -113,12 +113,12 @@ class SubjectAccessRequestGatewayTest {
       val expiredClaimDateTime = "01/01/2024 23:55"
       val expiredClaimDateTimeFormatted = LocalDateTime.parse(expiredClaimDateTime, dateTimeFormatter)
       SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true, formattedMockedCurrentTime)
+        .getSubjectAccessRequests(unclaimedOnly = true, filters = "", formattedMockedCurrentTime)
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
     }
 
     @Test
-    fun `returns joint list of both claimed and valid unclaimed sars`() {
+    fun `returns joint list of both claimed and valid unclaimed sars if unclaimed is true`() {
       Mockito.`when`(sarRepository.findByStatusIsAndClaimAttemptsIs(Status.Pending, 0)).thenReturn(mockSarsWithNoClaims)
       val mockedCurrentTime = "02/01/2024 00:00"
       val formattedMockedCurrentTime = LocalDateTime.parse(mockedCurrentTime, dateTimeFormatter)
@@ -128,8 +128,17 @@ class SubjectAccessRequestGatewayTest {
         emptyList(),
       )
       val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
-        .getSubjectAccessRequests(unclaimedOnly = true, formattedMockedCurrentTime)
+        .getSubjectAccessRequests(unclaimedOnly = true, filters = "", formattedMockedCurrentTime)
       verify(sarRepository, times(1)).findByStatusIsAndClaimAttemptsGreaterThanAndClaimDateTimeBefore(Status.Pending, 0, expiredClaimDateTimeFormatted)
+      Assertions.assertTrue(result.size == 3)
+    }
+
+    @Test
+    fun `passes correct parameters and returns filtered list if unclaimed is false and filters are provided`() {
+      Mockito.`when`(sarRepository.findFilteredRecords("TEST_REF", "TEST_ID")).thenReturn(mockSarsWithNoClaims)
+      val result: List<SubjectAccessRequest?> = SubjectAccessRequestGateway(sarRepository)
+        .getSubjectAccessRequests(unclaimedOnly = false, filters = "{\"sarCaseReferenceNumber\":\"TEST_REF\",\"subjectId\":\"TEST_ID\"}")
+      verify(sarRepository, times(1)).findFilteredRecords(sarCaseReferenceNumber = "TEST_REF", subjectId = "TEST_ID")
       Assertions.assertTrue(result.size == 3)
     }
   }


### PR DESCRIPTION
This adds filters for the /subjectAccessRequests endpoint. You can filter on either sarCaseReferenceNumber or subjectId.

Only records matching all provided filters will be returned. Filters apply to a substring (eg. "A12" will match any nomis ID or ndelius ID that contains "A12" anywhere within it.)

To use a filter, add the 'filters' query variable, which is a URL encoded JSON string with keys for each filter that you want to apply. Any extra provided filters are ignored. If unclaimedOnly is set to true, filters are ignored, so all unclaimed SAR reports will be returned.

Example request:
`[API URL]/api/subjectAccessRequests?filter=%7B"subjectId":"A12","sarCaseReferenceNumber":"TEST_REF"%7D`
(%7B and %7D are the URL encodings of { and }, respectively)