### PR TITLE
Haar 3375 fail jobs after timeout

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -8,7 +8,7 @@ services:
     container_name: sar-db
     restart: always
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       - POSTGRES_PASSWORD=admin_password
       - POSTGRES_USER=admin

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -8,7 +8,7 @@ services:
     container_name: sar-db
     restart: always
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=admin_password
       - POSTGRES_USER=admin

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/config/AlertsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/config/AlertsConfiguration.kt
@@ -30,4 +30,6 @@ class AlertsConfiguration(
    */
   fun calculateTimeoutThreshold(): LocalDateTime =
     LocalDateTime.now().minus(timeoutThreshold, timeoutThresholdChronoUnit)
+
+  fun timeoutThresholdAsString() = "$timeoutThreshold $timeoutThresholdChronoUnit"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/config/AlertsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/config/AlertsConfiguration.kt
@@ -7,29 +7,36 @@ import java.time.temporal.ChronoUnit
 
 @Configuration
 class AlertsConfiguration(
-  @Value("\${application.alerts.reports-overdue.threshold:12}") val overdueThreshold: Long,
-  @Value("\${application.alerts.reports-overdue.threshold-unit:HOURS}") val overdueThresholdChronoUnit: ChronoUnit,
-  @Value("\${application.alerts.reports-overdue.alert-frequency:720}") val overdueAlertFrequencyMinutes: Int,
-  @Value("\${application.alerts.backlog-threshold.threshold:100}") val backlogThreshold: Int,
-  @Value("\${application.alerts.backlog-threshold.alert-frequency:720}") val backlogThresholdAlertFrequency: Int,
-  @Value("\${application.alerts.report-timeout.threshold:720}") val timeoutThreshold: Long,
-  @Value("\${application.alerts.report-timeout.threshold-unit:HOURS}") val timeoutThresholdChronoUnit: ChronoUnit,
+  val overdueAlertConfig: OverdueAlertConfiguration,
+  val backlogAlertConfig: BacklogAlertConfiguration,
+  val requestTimeoutAlertConfig: RequestTimeoutAlertConfiguration,
+)
+
+@Configuration
+class OverdueAlertConfiguration(
+  @Value("\${application.alerts.reports-overdue.threshold:12}") val threshold: Long,
+  @Value("\${application.alerts.reports-overdue.threshold-unit:HOURS}") val thresholdChronoUnit: ChronoUnit,
+  @Value("\${application.alerts.reports-overdue.alert-interval-minutes:720}") val alertIntervalMinutes: Int,
 ) {
+  fun calculateOverdueThreshold(): LocalDateTime = LocalDateTime.now().minus(threshold, thresholdChronoUnit)
+  fun thresholdAsString() = "$threshold $thresholdChronoUnit"
+  fun thresholdAlertFrequency() = "$alertIntervalMinutes ${ChronoUnit.MINUTES}"
+}
 
-  fun calculateOverdueThreshold(): LocalDateTime =
-    LocalDateTime.now().minus(overdueThreshold, overdueThresholdChronoUnit)
+@Configuration
+class BacklogAlertConfiguration(
+  @Value("\${application.alerts.backlog-threshold.threshold:100}") val threshold: Int,
+  @Value("\${application.alerts.backlog-threshold.alert-interval-minutes:720}") val alertIntervalMinutes: Int,
+) {
+  fun thresholdAlertFrequency() = "$alertIntervalMinutes ${ChronoUnit.MINUTES}"
+}
 
-  fun overdueThresholdAsString() = "$overdueThreshold $overdueThresholdChronoUnit"
-
-  fun overdueThresholdAlertFrequency() = "$overdueAlertFrequencyMinutes ${ChronoUnit.MINUTES}"
-
-  fun backlogThresholdAlertFrequency() = "$backlogThresholdAlertFrequency ${ChronoUnit.MINUTES}"
-
-  /**
-   * Returns LocalDateTime.now() - (timeout threshold)
-   */
-  fun calculateTimeoutThreshold(): LocalDateTime =
-    LocalDateTime.now().minus(timeoutThreshold, timeoutThresholdChronoUnit)
-
-  fun timeoutThresholdAsString() = "$timeoutThreshold $timeoutThresholdChronoUnit"
+@Configuration
+class RequestTimeoutAlertConfiguration(
+  @Value("\${application.alerts.report-timeout.threshold:48}") val threshold: Long,
+  @Value("\${application.alerts.report-timeout.threshold-unit:HOURS}") val thresholdChronoUnit: ChronoUnit,
+  @Value("\${application.alerts.report-timeout.alert-interval-minutes:}") val alertIntervalMinutes: Int,
+) {
+  fun calculateTimeoutThreshold(): LocalDateTime = LocalDateTime.now().minus(threshold, thresholdChronoUnit)
+  fun thresholdAsString() = "$threshold $thresholdChronoUnit"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/config/AlertsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/config/AlertsConfiguration.kt
@@ -12,6 +12,8 @@ class AlertsConfiguration(
   @Value("\${application.alerts.reports-overdue.alert-frequency:720}") val overdueAlertFrequencyMinutes: Int,
   @Value("\${application.alerts.backlog-threshold.threshold:100}") val backlogThreshold: Int,
   @Value("\${application.alerts.backlog-threshold.alert-frequency:720}") val backlogThresholdAlertFrequency: Int,
+  @Value("\${application.alerts.report-timeout.threshold:720}") val timeoutThreshold: Long,
+  @Value("\${application.alerts.report-timeout.threshold-unit:HOURS}") val timeoutThresholdChronoUnit: ChronoUnit,
 ) {
 
   fun calculateOverdueThreshold(): LocalDateTime =
@@ -22,4 +24,10 @@ class AlertsConfiguration(
   fun overdueThresholdAlertFrequency() = "$overdueAlertFrequencyMinutes ${ChronoUnit.MINUTES}"
 
   fun backlogThresholdAlertFrequency() = "$backlogThresholdAlertFrequency ${ChronoUnit.MINUTES}"
+
+  /**
+   * Returns LocalDateTime.now() - (timeout threshold)
+   */
+  fun calculateTimeoutThreshold(): LocalDateTime =
+    LocalDateTime.now().minus(timeoutThreshold, timeoutThresholdChronoUnit)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -469,4 +469,11 @@ class SubjectAccessRequestController(
       alertFrequency = alertsConfiguration.overdueThresholdAlertFrequency(),
     ),
   )
+
+  @GetMapping("/subjectAccessRequests/expire")
+  @PreAuthorize("hasRole('ROLE_SAR_SUPPORT')")
+  fun timeoutPendingJobs(): ResponseEntity<List<String>> {
+    val updated = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
+    return ResponseEntity<List<String>>(updated.map { it.id.toString() }, HttpStatus.OK)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -46,6 +46,8 @@ class SubjectAccessRequestController(
   val alertsConfiguration: AlertsConfiguration,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
+  private val overdueAlertConfig = alertsConfiguration.overdueAlertConfig
+  private val backlogAlertConfig = alertsConfiguration.backlogAlertConfig
 
   @PostMapping("/subjectAccessRequest")
   @Operation(
@@ -460,13 +462,13 @@ class SubjectAccessRequestController(
   fun getServiceSummary(): ServiceSummary = ServiceSummary(
     BacklogSummary(
       count = subjectAccessRequestService.countPendingSubjectAccessRequests(),
-      alertThreshold = alertsConfiguration.backlogThreshold,
-      alertFrequency = alertsConfiguration.backlogThresholdAlertFrequency(),
+      alertThreshold = backlogAlertConfig.threshold,
+      alertFrequency = backlogAlertConfig.thresholdAlertFrequency(),
     ),
     OverdueReportSummary(
       count = subjectAccessRequestService.getOverdueSubjectAccessRequestsSummary().total,
-      alertThreshold = "status == pending && requestDateTime < (time.now - ${alertsConfiguration.overdueThresholdAsString()})",
-      alertFrequency = alertsConfiguration.overdueThresholdAlertFrequency(),
+      alertThreshold = "status == pending && requestDateTime < (time.now - ${overdueAlertConfig.thresholdAsString()})",
+      alertFrequency = overdueAlertConfig.thresholdAlertFrequency(),
     ),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestController.kt
@@ -469,11 +469,4 @@ class SubjectAccessRequestController(
       alertFrequency = alertsConfiguration.overdueThresholdAlertFrequency(),
     ),
   )
-
-  @GetMapping("/subjectAccessRequests/expire")
-  @PreAuthorize("hasRole('ROLE_SAR_SUPPORT')")
-  fun timeoutPendingJobs(): ResponseEntity<List<String>> {
-    val updated = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
-    return ResponseEntity<List<String>>(updated.map { it.id.toString() }, HttpStatus.OK)
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/exceptions/SubjectAccessRequestAlertException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/exceptions/SubjectAccessRequestAlertException.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions
+
+class SubjectAccessRequestBacklogThresholdException(message: String) : RuntimeException(message)
+
+class SubjectAccessRequestTimeoutException(message: String, private val requestIds: List<String>) : RuntimeException(message) {
+  override val message: String
+    get() = "${super.message}: \n\nRequests:\n${requestIds.joinToString("\n")}"
+}
+
+class SubjectAccessRequestProcessingOverdueException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/exceptions/SubjectAccessRequestBacklogThresholdException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/exceptions/SubjectAccessRequestBacklogThresholdException.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions
-
-class SubjectAccessRequestBacklogThresholdException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/exceptions/SubjectAccessRequestProcessingOverdueException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/exceptions/SubjectAccessRequestProcessingOverdueException.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions
-
-class SubjectAccessRequestProcessingOverdueException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/models/SubjectAccessRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/models/SubjectAccessRequest.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 enum class Status {
   Pending,
   Completed,
+  Errored,
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -1,10 +1,14 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.repository
 
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.Status
@@ -12,8 +16,13 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.SubjectAccess
 import java.time.LocalDateTime
 import java.util.UUID
 
+const val LOCK_TIMEOUT = "3000"
+
 @Repository
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, UUID> {
+
+  @Lock(LockModeType.PESSIMISTIC_READ)
+  @QueryHints( value = [QueryHint(name = "javax.persistence.lock.timeout", value = LOCK_TIMEOUT)])
   @Query(
     "SELECT report FROM SubjectAccessRequest report " +
       "WHERE (report.status = 'Pending' " +
@@ -24,15 +33,25 @@ interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, U
   )
   fun findUnclaimed(@Param("claimDateTime") claimDateTime: LocalDateTime): List<SubjectAccessRequest?>
 
-  fun findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(caseReferenceSearch: String, nomisSearch: String, ndeliusSearch: String, pagination: Pageable): Page<SubjectAccessRequest?>
+  fun findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(
+    caseReferenceSearch: String,
+    nomisSearch: String,
+    ndeliusSearch: String,
+    pagination: Pageable,
+  ): Page<SubjectAccessRequest?>
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
     "UPDATE SubjectAccessRequest report " +
       "SET report.claimDateTime = :currentTime, report.claimAttempts = report.claimAttempts + 1" +
-      "WHERE (report.id = :id AND report.claimDateTime < :releaseThreshold) OR (report.id = :id AND report.claimDateTime IS NULL)",
+      "WHERE (report.status = 'Pending' AND report.id = :id AND report.claimDateTime < :releaseThreshold) " +
+      "OR (report.status = 'Pending' AND report.id = :id AND report.claimDateTime IS NULL)",
   )
-  fun updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(@Param("id") id: UUID, @Param("releaseThreshold") releaseThreshold: LocalDateTime, @Param("currentTime") currentTime: LocalDateTime): Int
+  fun updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
+    @Param("id") id: UUID,
+    @Param("releaseThreshold") releaseThreshold: LocalDateTime,
+    @Param("currentTime") currentTime: LocalDateTime,
+  ): Int
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
@@ -52,14 +71,24 @@ interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, U
 
   fun findByRequestDateTimeBefore(thresholdTime: LocalDateTime): List<SubjectAccessRequest?>
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints( value = [QueryHint(name = "javax.persistence.lock.timeout", value = "3000")])
   @Query(
     "SELECT s FROM SubjectAccessRequest s " +
       "WHERE :threshold > s.requestDateTime " +
       "AND s.status = 'Pending' " +
       "ORDER BY s.requestDateTime ASC",
   )
-  fun findOverdueSubjectAccessRequests(@Param("threshold") threshold: LocalDateTime): List<SubjectAccessRequest?>
+  fun findAllPendingSubjectAccessRequestsSubmittedBefore(@Param("threshold") threshold: LocalDateTime): List<SubjectAccessRequest?>
 
+  @Lock(LockModeType.PESSIMISTIC_READ)
+  @QueryHints( value = [QueryHint(name = "javax.persistence.lock.timeout", value = "3000")])
   @Query("SELECT COUNT(1) FROM SubjectAccessRequest s WHERE s.status = :status")
   fun countSubjectAccessRequestsByStatus(@Param("status") status: Status): Int
+
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("UPDATE SubjectAccessRequest s SET s.status = 'Errored' WHERE s.id = :id AND s.status = 'Pending' AND :threshold > s.requestDateTime")
+  fun updateStatusToErrorSubmittedBefore(@Param("id") id: UUID, @Param("threshold") threshold: LocalDateTime): Int
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepository.kt
@@ -22,7 +22,7 @@ const val LOCK_TIMEOUT = "3000"
 interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, UUID> {
 
   @Lock(LockModeType.PESSIMISTIC_READ)
-  @QueryHints( value = [QueryHint(name = "javax.persistence.lock.timeout", value = LOCK_TIMEOUT)])
+  @QueryHints(value = [QueryHint(name = "javax.persistence.lock.timeout", value = LOCK_TIMEOUT)])
   @Query(
     "SELECT report FROM SubjectAccessRequest report " +
       "WHERE (report.status = 'Pending' " +
@@ -72,7 +72,7 @@ interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, U
   fun findByRequestDateTimeBefore(thresholdTime: LocalDateTime): List<SubjectAccessRequest?>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints( value = [QueryHint(name = "javax.persistence.lock.timeout", value = "3000")])
+  @QueryHints(value = [QueryHint(name = "javax.persistence.lock.timeout", value = LOCK_TIMEOUT)])
   @Query(
     "SELECT s FROM SubjectAccessRequest s " +
       "WHERE :threshold > s.requestDateTime " +
@@ -82,13 +82,11 @@ interface SubjectAccessRequestRepository : JpaRepository<SubjectAccessRequest, U
   fun findAllPendingSubjectAccessRequestsSubmittedBefore(@Param("threshold") threshold: LocalDateTime): List<SubjectAccessRequest?>
 
   @Lock(LockModeType.PESSIMISTIC_READ)
-  @QueryHints( value = [QueryHint(name = "javax.persistence.lock.timeout", value = "3000")])
+  @QueryHints(value = [QueryHint(name = "javax.persistence.lock.timeout", value = LOCK_TIMEOUT)])
   @Query("SELECT COUNT(1) FROM SubjectAccessRequest s WHERE s.status = :status")
   fun countSubjectAccessRequestsByStatus(@Param("status") status: Status): Int
-
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("UPDATE SubjectAccessRequest s SET s.status = 'Errored' WHERE s.id = :id AND s.status = 'Pending' AND :threshold > s.requestDateTime")
   fun updateStatusToErrorSubmittedBefore(@Param("id") id: UUID, @Param("threshold") threshold: LocalDateTime): Int
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/AlertsService.kt
@@ -8,7 +8,9 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfigu
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.trackEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions.SubjectAccessRequestBacklogThresholdException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions.SubjectAccessRequestProcessingOverdueException
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions.SubjectAccessRequestTimeoutException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.OverdueSubjectAccessRequests
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.SubjectAccessRequest
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -22,10 +24,13 @@ class AlertsService(
     private val dataTimeFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
     private const val OVERDUE_REPORTS_MESSAGE =
-      "Warning: %d reports with status 'Pending' have exceeded the processing overdue threshold: '%s'"
+      "Warning: %d 'Pending' requests have exceeded the processing overdue threshold: '%s'"
 
     private const val BACKLOG_THRESHOLD_EXCEEDED_MESSAGE =
       "Warning: Pending reports backlog threshold exceeded - timestamp: %s, threshold: %d, backlog: %d "
+
+    private const val REQUESTS_TIMED_OUT_MESSAGE =
+      "Warning: %d requests updated to status 'Errored' after not completing within the processing threshold: '%s'"
   }
 
   fun raiseUnexpectedExceptionAlert(exception: Exception, properties: Map<String, String>? = null) {
@@ -75,5 +80,23 @@ class AlertsService(
       ),
     )
     Sentry.captureException(SubjectAccessRequestBacklogThresholdException(msg))
+  }
+
+  fun raiseReportsTimedOutAlert(timedOutRequests: List<SubjectAccessRequest?>) {
+    val msg = REQUESTS_TIMED_OUT_MESSAGE.format(
+      timedOutRequests.size,
+      alertConfig.timeoutThresholdAsString(),
+    )
+    log.warn(msg)
+
+    telemetryClient.trackEvent(
+      "RequestsTimeoutAlert",
+      mapOf(
+        "backlog" to timedOutRequests.toString(),
+        "threshold" to alertConfig.timeoutThreshold.toString(),
+        "timestamp" to LocalDateTime.now().format(dataTimeFmt),
+      ),
+    )
+    Sentry.captureException(SubjectAccessRequestTimeoutException(msg, timedOutRequests.map { it?.id.toString() }))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/AlertsService.kt
@@ -19,6 +19,7 @@ class AlertsService(
   val telemetryClient: TelemetryClient,
   val alertConfig: AlertsConfiguration,
 ) {
+
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
     private val dataTimeFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
@@ -46,7 +47,7 @@ class AlertsService(
   }
 
   fun raiseOverdueReportAlert(overdueReports: List<OverdueSubjectAccessRequests?>) {
-    val msg = OVERDUE_REPORTS_MESSAGE.format(overdueReports.size, alertConfig.overdueThresholdAsString())
+    val msg = OVERDUE_REPORTS_MESSAGE.format(overdueReports.size, alertConfig.overdueAlertConfig.thresholdAsString())
 
     log.warn(msg)
 
@@ -55,7 +56,7 @@ class AlertsService(
       mapOf(
         "count" to overdueReports.size.toString(),
         "timestamp" to LocalDateTime.now().format(dataTimeFmt),
-        "overdueThreshold" to alertConfig.overdueThresholdAsString(),
+        "overdueThreshold" to alertConfig.overdueAlertConfig.thresholdAsString(),
       ),
     )
 
@@ -65,8 +66,8 @@ class AlertsService(
   fun raiseReportBacklogThresholdAlert(backlogSize: Int) {
     val msg = BACKLOG_THRESHOLD_EXCEEDED_MESSAGE.format(
       dataTimeFmt.format(LocalDateTime.now()),
+      alertConfig.backlogAlertConfig.threshold,
       backlogSize,
-      alertConfig.backlogThreshold,
     )
 
     log.warn(msg)
@@ -75,7 +76,7 @@ class AlertsService(
       "PendingRequestsBacklogThresholdAlert",
       mapOf(
         "backlog" to backlogSize.toString(),
-        "threshold" to alertConfig.backlogThreshold.toString(),
+        "threshold" to alertConfig.backlogAlertConfig.threshold.toString(),
         "timestamp" to LocalDateTime.now().format(dataTimeFmt),
       ),
     )
@@ -85,7 +86,7 @@ class AlertsService(
   fun raiseReportsTimedOutAlert(timedOutRequests: List<SubjectAccessRequest?>) {
     val msg = REQUESTS_TIMED_OUT_MESSAGE.format(
       timedOutRequests.size,
-      alertConfig.timeoutThresholdAsString(),
+      alertConfig.requestTimeoutAlertConfig.thresholdAsString(),
     )
     log.warn(msg)
 
@@ -93,7 +94,7 @@ class AlertsService(
       "RequestsTimeoutAlert",
       mapOf(
         "backlog" to timedOutRequests.toString(),
-        "threshold" to alertConfig.timeoutThreshold.toString(),
+        "threshold" to alertConfig.requestTimeoutAlertConfig.thresholdAsString(),
         "timestamp" to LocalDateTime.now().format(dataTimeFmt),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -128,6 +128,7 @@ class SubjectAccessRequestService(
     return document
   }
 
+  @Transactional
   fun getOverdueSubjectAccessRequestsSummary(): ReportsOverdueSummary {
     val threshold = alertsConfiguration.calculateOverdueThreshold()
     val overdue = subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(threshold)
@@ -150,6 +151,7 @@ class SubjectAccessRequestService(
     )
   }
 
+  @Transactional
   fun countPendingSubjectAccessRequests(): Int {
     return subjectAccessRequestRepository.countSubjectAccessRequestsByStatus(Status.Pending)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -125,7 +125,7 @@ class SubjectAccessRequestService(
 
   @Transactional
   fun getOverdueSubjectAccessRequestsSummary(): ReportsOverdueSummary {
-    val threshold = alertsConfiguration.calculateOverdueThreshold()
+    val threshold = alertsConfiguration.overdueAlertConfig.calculateOverdueThreshold()
     val overdue = subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(threshold)
 
     val overdueRequests = overdue.map {
@@ -141,7 +141,7 @@ class SubjectAccessRequestService(
       }
     }
     return ReportsOverdueSummary(
-      alertsConfiguration.overdueThresholdAsString(),
+      alertsConfiguration.overdueAlertConfig.thresholdAsString(),
       overdueRequests,
     )
   }
@@ -153,7 +153,7 @@ class SubjectAccessRequestService(
 
   @Transactional()
   fun expirePendingRequestsSubmittedBeforeThreshold(): List<SubjectAccessRequest> {
-    val threshold = alertsConfiguration.calculateTimeoutThreshold()
+    val threshold = alertsConfiguration.requestTimeoutAlertConfig.calculateTimeoutThreshold()
     val expiredRequests = mutableListOf<SubjectAccessRequest>()
 
     subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(threshold).forEach {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -27,7 +27,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 @Service
 class SubjectAccessRequestService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services
 
 import com.microsoft.applicationinsights.TelemetryClient
-import jakarta.transaction.Transactional
 import org.apache.commons.lang3.ObjectUtils.isNotEmpty
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.InputStreamResource
@@ -11,6 +10,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.client.DocumentStorageClient
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestService.kt
@@ -57,10 +57,6 @@ class SubjectAccessRequestService(
       )
     }
 
-//    if (request.dateTo == null) {
-//      request.dateTo = LocalDate.now()
-//    }
-
     val subjectAccessRequest = SubjectAccessRequest(
       id = id ?: UUID.randomUUID(),
       status = Status.Pending,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/BacklogThresholdAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/BacklogThresholdAlert.kt
@@ -11,19 +11,20 @@ import java.util.concurrent.TimeUnit
 class BacklogThresholdAlert(
   private val subjectAccessRequestService: SubjectAccessRequestService,
   private val alertsService: AlertsService,
-  alertsConfiguration: AlertsConfiguration,
+  private val alertsConfiguration: AlertsConfiguration,
 ) {
 
-  private val threshold = alertsConfiguration.backlogThreshold
-
+  /**
+   * Scheduled task to raise alert notifications if the backlog of Pending requests exceeds the configured threshold.
+   */
   @Scheduled(
-    fixedDelayString = "\${application.alerts.backlog-threshold.alert-frequency:720}",
+    fixedDelayString = "\${application.alerts.backlog-threshold.alert-interval-minutes:720}",
     timeUnit = TimeUnit.MINUTES,
   )
   fun execute() {
     try {
       val backlogSize = subjectAccessRequestService.countPendingSubjectAccessRequests()
-      if (backlogSize > threshold) {
+      if (backlogSize > alertsConfiguration.backlogAlertConfig.threshold) {
         alertsService.raiseReportBacklogThresholdAlert(backlogSize)
       }
     } catch (ex: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/BacklogThresholdAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/BacklogThresholdAlert.kt
@@ -20,6 +20,7 @@ class BacklogThresholdAlert(
   @Scheduled(
     fixedDelayString = "\${application.alerts.backlog-threshold.alert-interval-minutes:720}",
     timeUnit = TimeUnit.MINUTES,
+    initialDelay = 60000,
   )
   fun execute() {
     try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsOverdueAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsOverdueAlert.kt
@@ -20,6 +20,7 @@ class ReportsOverdueAlert(
   @Scheduled(
     fixedDelayString = "\${application.alerts.reports-overdue.alert-interval-minutes:720}",
     timeUnit = TimeUnit.MINUTES,
+    initialDelay = 60000,
   )
   fun execute() {
     Status.Pending

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsOverdueAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsOverdueAlert.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.timed.alerts
 
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.Status
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.AlertsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.SubjectAccessRequestService
 import java.util.concurrent.TimeUnit
@@ -13,15 +14,15 @@ class ReportsOverdueAlert(
 ) {
 
   /**
-   * Scheduled task to raise alerts for subject access requests that have exceeded the processing overdue threshold
-   * (see: [uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfiguration]) Default is
-   * 12 hours
+   * Scheduled task to raise alerts if there are subject access requests with status
+   * [uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.Status.Pending] submitted before Time.now - threshold.
    */
   @Scheduled(
-    fixedDelayString = "\${application.alerts.reports-overdue.alert-frequency:720}",
+    fixedDelayString = "\${application.alerts.reports-overdue.alert-interval-minutes:720}",
     timeUnit = TimeUnit.MINUTES,
   )
   fun execute() {
+    Status.Pending
     try {
       val overdueReports = subjectAccessRequestService.getOverdueSubjectAccessRequestsSummary()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
@@ -20,6 +20,7 @@ class ReportsTimedOutAlert(
   @Scheduled(
     fixedDelayString = "\${application.alerts.report-timeout.alert-interval-minutes:2880}",
     timeUnit = TimeUnit.MINUTES,
+    initialDelay = 60000,
   )
   fun execute() {
     try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
@@ -25,7 +25,8 @@ class ReportsTimedOutAlert(
     } catch (ex: Exception) {
       alertsService.raiseUnexpectedExceptionAlert(
         RuntimeException(
-          "ReportsTimedOutAlert threw unexpected exception", ex,
+          "ReportsTimedOutAlert threw unexpected exception",
+          ex,
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
@@ -12,8 +12,13 @@ class ReportsTimedOutAlert(
   val alertsService: AlertsService,
 ) {
 
+  /**
+   * Scheduled task to fail any requests with status == 'Pending' submitted before the configured threshold
+   * (default is 48 hours). Requests matching the criteria are considered to have failed. Identified requests are updated
+   * with status 'Errored' and alert notification is raise to prompt the team to investigate.
+   */
   @Scheduled(
-    fixedDelayString = "\${application.alerts.report-timeout.alert-frequency}",
+    fixedDelayString = "\${application.alerts.report-timeout.alert-interval-minutes:2880}",
     timeUnit = TimeUnit.MINUTES,
   )
   fun execute() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlert.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.timed.alerts
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.AlertsService
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.SubjectAccessRequestService
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+@Component
+class ReportsTimedOutAlert(
+  val subjectAccessRequestService: SubjectAccessRequestService,
+  val alertsService: AlertsService
+) {
+
+  @Scheduled(
+    fixedDelayString = "\${application.alerts.report-timeout.alert-frequency}",
+    timeUnit = TimeUnit.MINUTES,
+  )
+  fun execute() {
+//    val expiredReports = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
+//    expiredReports.takeIf { it.isNotEmpty() }?.let {
+//      alertsService
+//    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,7 @@ application:
       alert-frequency: 720
       threshold: 100
     report-timeout:
-      alert-frequency: 1
+      alert-frequency: 720
       threshold:  1
       threshold-unit: HOURS
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,7 +88,7 @@ application:
       threshold: 100
     report-timeout:
       alert-frequency: 720
-      threshold:  1
+      threshold:  48
       threshold-unit: HOURS
 
 management:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,10 @@ application:
     backlog-threshold:
       alert-frequency: 720
       threshold: 100
+    report-timeout:
+      alert-frequency: 1
+      threshold:  1
+      threshold-unit: HOURS
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,14 +80,14 @@ application:
     frequency: 3600000
   alerts:
     reports-overdue:
-      alert-frequency: 720
+      alert-interval-minutes: 720
       threshold: 12
       threshold-unit: HOURS
     backlog-threshold:
-      alert-frequency: 720
+      alert-interval-minutes: 720
       threshold: 100
     report-timeout:
-      alert-frequency: 720
+      alert-interval-minutes: 720
       threshold:  48
       threshold-unit: HOURS
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestControllerGetOverdueIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestControllerGetOverdueIntTest.kt
@@ -5,10 +5,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfiguration
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.OverdueAlertConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.ReportsOverdueSummary
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.Status
@@ -26,8 +28,9 @@ class SubjectAccessRequestControllerGetOverdueIntTest : IntegrationTestBase() {
   @Autowired
   private lateinit var subjectAccessRequestRepository: SubjectAccessRequestRepository
 
-  @MockBean
+  @MockitoBean
   private lateinit var alertConfiguration: AlertsConfiguration
+  private var overdueAlertConfig: OverdueAlertConfiguration = mock()
 
   companion object {
     private val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
@@ -69,10 +72,11 @@ class SubjectAccessRequestControllerGetOverdueIntTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    whenever(alertConfiguration.overdueThreshold).thenReturn(1)
-    whenever(alertConfiguration.overdueThresholdChronoUnit).thenReturn(ChronoUnit.HOURS)
-    whenever(alertConfiguration.calculateOverdueThreshold()).thenReturn(dateTimeNow.minusHours(1))
-    whenever(alertConfiguration.overdueThresholdAsString()).thenReturn("1 Hours")
+    whenever(alertConfiguration.overdueAlertConfig).thenReturn(overdueAlertConfig)
+    whenever(overdueAlertConfig.threshold).thenReturn(1)
+    whenever(overdueAlertConfig.thresholdChronoUnit).thenReturn(ChronoUnit.HOURS)
+    whenever(overdueAlertConfig.calculateOverdueThreshold()).thenReturn(dateTimeNow.minusHours(1))
+    whenever(overdueAlertConfig.thresholdAsString()).thenReturn("1 Hours")
 
     subjectAccessRequestRepository.deleteAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestControllerGetOverdueIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/controllers/SubjectAccessRequestControllerGetOverdueIntTest.kt
@@ -75,8 +75,8 @@ class SubjectAccessRequestControllerGetOverdueIntTest : IntegrationTestBase() {
     whenever(alertConfiguration.overdueAlertConfig).thenReturn(overdueAlertConfig)
     whenever(overdueAlertConfig.threshold).thenReturn(1)
     whenever(overdueAlertConfig.thresholdChronoUnit).thenReturn(ChronoUnit.HOURS)
-    whenever(overdueAlertConfig.calculateOverdueThreshold()).thenReturn(dateTimeNow.minusHours(1))
     whenever(overdueAlertConfig.thresholdAsString()).thenReturn("1 Hours")
+    whenever(overdueAlertConfig.calculateOverdueThreshold()).thenReturn(dateTimeNow.minusHours(1))
 
     subjectAccessRequestRepository.deleteAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -568,21 +568,6 @@ class SubjectAccessRequestRepositoryTest {
     }
 
     @Test
-    fun `should not update status to Errored for request with status Pending submitted at threshold`() {
-      val now = LocalDateTime.now()
-      val sar = insertSarSubmittedAtWithStatus(now.minusHours(12), Status.Pending)
-
-      val count = subjectAccessRequestRepository.updateStatusToErrorSubmittedBefore(sar.id, now.minusHours(12))
-      assertThat(count).isEqualTo(0)
-
-      assertSubjectAccessRequestHasStatus(
-        actual = subjectAccessRequestRepository.findById(sar.id),
-        expectedStatus = Status.Pending,
-        expectedId = sar.id,
-      )
-    }
-
-    @Test
     fun `should not update status to Errored for request with status Completed submitted before threshold`() {
       val now = LocalDateTime.now()
       val sar = insertSarSubmittedAtWithStatus(now.minusHours(48), Status.Completed)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/repository/SubjectAccessRequestRepositoryTest.kt
@@ -181,11 +181,12 @@ class SubjectAccessRequestRepositoryTest {
         claimDateTime = currentDateTime,
       )
 
-      val numberOfDbRecordsUpdated = subjectAccessRequestRepository.updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
-        sarWithPendingStatusClaimedEarlier.id,
-        thresholdClaimDateTime,
-        currentDateTime,
-      )
+      val numberOfDbRecordsUpdated =
+        subjectAccessRequestRepository.updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
+          sarWithPendingStatusClaimedEarlier.id,
+          thresholdClaimDateTime,
+          currentDateTime,
+        )
 
       assertThat(numberOfDbRecordsUpdated).isEqualTo(1)
       assertThat(subjectAccessRequestRepository.findAll().size).isEqualTo(6)
@@ -215,11 +216,12 @@ class SubjectAccessRequestRepositoryTest {
         claimDateTime = claimDateTime,
       )
 
-      val numberOfDbRecordsUpdated = subjectAccessRequestRepository.updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
-        claimedSarWithPendingStatus.id,
-        thresholdClaimDateTime,
-        currentDateTime,
-      )
+      val numberOfDbRecordsUpdated =
+        subjectAccessRequestRepository.updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
+          claimedSarWithPendingStatus.id,
+          thresholdClaimDateTime,
+          currentDateTime,
+        )
 
       assertThat(numberOfDbRecordsUpdated).isEqualTo(0)
       assertThat(subjectAccessRequestRepository.findAll().size).isEqualTo(6)
@@ -251,11 +253,12 @@ class SubjectAccessRequestRepositoryTest {
 
       subjectAccessRequestRepository.save(completedSar)
 
-      val numberOfDbRecordsUpdated = subjectAccessRequestRepository.updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
-        completedSar.id,
-        thresholdClaimDateTime,
-        currentDateTime,
-      )
+      val numberOfDbRecordsUpdated =
+        subjectAccessRequestRepository.updateClaimDateTimeAndClaimAttemptsIfBeforeThreshold(
+          completedSar.id,
+          thresholdClaimDateTime,
+          currentDateTime,
+        )
 
       assertThat(numberOfDbRecordsUpdated).isEqualTo(0)
       assertThat(subjectAccessRequestRepository.findAll().size).isEqualTo(1)
@@ -308,7 +311,13 @@ class SubjectAccessRequestRepositoryTest {
 
       databaseInsert()
 
-      val result = subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase("test", "test", "test", PageRequest.of(1, 1, Sort.by("RequestDateTime").descending()))?.content
+      val result =
+        subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(
+          "test",
+          "test",
+          "test",
+          PageRequest.of(1, 1, Sort.by("RequestDateTime").descending()),
+        )?.content
 
       assertThat(subjectAccessRequestRepository.findAll()).isEqualTo(allSars)
       assertThat(result).isEqualTo(expectedSearchResult)
@@ -316,11 +325,18 @@ class SubjectAccessRequestRepositoryTest {
 
     @Test
     fun `findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase returns all entries containing given string sorted on request date when unpaged`() {
-      val expectedSearchResult: List<SubjectAccessRequest> = listOf(sarWithSearchableNdeliusId, sarWithSearchableCaseReference)
+      val expectedSearchResult: List<SubjectAccessRequest> =
+        listOf(sarWithSearchableNdeliusId, sarWithSearchableCaseReference)
 
       databaseInsert()
 
-      val result = subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase("test", "test", "test", Pageable.unpaged(Sort.by("RequestDateTime").descending()))?.content
+      val result =
+        subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(
+          "test",
+          "test",
+          "test",
+          Pageable.unpaged(Sort.by("RequestDateTime").descending()),
+        )?.content
 
       assertThat(subjectAccessRequestRepository.findAll()).isEqualTo(allSars)
       assertThat(result).isEqualTo(expectedSearchResult)
@@ -330,14 +346,15 @@ class SubjectAccessRequestRepositoryTest {
     fun `findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase returns all SAR entries when searching on blank strings`() {
       databaseInsert()
 
-      val result = subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(
-        "",
-        "",
-        "",
-        Pageable.unpaged(
-          Sort.by("RequestDateTime").descending(),
-        ),
-      ).content
+      val result =
+        subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(
+          "",
+          "",
+          "",
+          Pageable.unpaged(
+            Sort.by("RequestDateTime").descending(),
+          ),
+        ).content
 
       assertThat(subjectAccessRequestRepository.findAll()).isEqualTo(allSars)
       assertThat(result).containsAll(allSars)
@@ -345,11 +362,18 @@ class SubjectAccessRequestRepositoryTest {
 
     @Test
     fun `findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase is case insensitive`() {
-      val expectedSearchResult: List<SubjectAccessRequest> = listOf(sarWithSearchableNdeliusId, sarWithSearchableCaseReference)
+      val expectedSearchResult: List<SubjectAccessRequest> =
+        listOf(sarWithSearchableNdeliusId, sarWithSearchableCaseReference)
 
       databaseInsert()
 
-      val result = subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase("TEST", "TEST", "TEST", Pageable.unpaged(Sort.by("RequestDateTime").descending()))?.content
+      val result =
+        subjectAccessRequestRepository.findBySarCaseReferenceNumberContainingIgnoreCaseOrNomisIdContainingIgnoreCaseOrNdeliusCaseReferenceIdContainingIgnoreCase(
+          "TEST",
+          "TEST",
+          "TEST",
+          Pageable.unpaged(Sort.by("RequestDateTime").descending()),
+        )?.content
 
       assertThat(subjectAccessRequestRepository.findAll()).isEqualTo(allSars)
       assertThat(result).isEqualTo(expectedSearchResult)
@@ -442,7 +466,8 @@ class SubjectAccessRequestRepositoryTest {
 
       insertSubjectAccessRequests(subjectAccessRequestSubmittedAt(dateTime10HoursAgo, Status.Completed))
 
-      val actual = subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(longRunningRequestThreshold)
+      val actual =
+        subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(longRunningRequestThreshold)
       assertThat(actual).isNotNull
       assertThat(actual).isEmpty()
     }
@@ -584,7 +609,7 @@ class SubjectAccessRequestRepositoryTest {
     }
   }
 
-  private fun insertSarSubmittedAtWithStatus(requestSubmittedAt: LocalDateTime, status: Status):SubjectAccessRequest {
+  private fun insertSarSubmittedAtWithStatus(requestSubmittedAt: LocalDateTime, status: Status): SubjectAccessRequest {
     val sar = subjectAccessRequestSubmittedAt(requestSubmittedAt, status)
     return subjectAccessRequestRepository.save(sar)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -2,18 +2,24 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.AdditionalMatchers
 import org.mockito.ArgumentCaptor
+import org.mockito.Captor
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.not
 import org.mockito.kotlin.whenever
 import org.springframework.core.io.InputStreamResource
 import org.springframework.data.domain.Page
@@ -38,18 +44,22 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
+@ExtendWith(MockitoExtension::class)
 class SubjectAccessRequestServiceTest {
 
   private val subjectAccessRequestRepository: SubjectAccessRequestRepository = mock()
   private val authentication: Authentication = mock()
   private val documentStorageClient: DocumentStorageClient = mock()
   private val telemetryClient: TelemetryClient = mock()
-  private val overdueAlertConfiguration: AlertsConfiguration = mock()
+  private val alertConfiguration: AlertsConfiguration = mock()
+
+  @Captor
+  private lateinit var sarIdCaptor: ArgumentCaptor<UUID>
 
   private val subjectAccessRequestService = SubjectAccessRequestService(
     documentStorageClient,
     subjectAccessRequestRepository,
-    overdueAlertConfiguration,
+    alertConfiguration,
     telemetryClient,
   )
 
@@ -363,6 +373,109 @@ class SubjectAccessRequestServiceTest {
       )
     }
   }
+
+  @Nested
+  inner class FailTimedOutRequests {
+
+    private lateinit var now: LocalDateTime
+    private lateinit var threshold: LocalDateTime
+
+    private lateinit var timedOutSar1: SubjectAccessRequest
+    private lateinit var timedOutSar2: SubjectAccessRequest
+    private lateinit var timedOutSar3: SubjectAccessRequest
+
+    @BeforeEach
+    fun setup() {
+      now = LocalDateTime.now()
+      threshold = now.minusHours(12)
+      timedOutSar1 = subjectAccessRequestSubmittedAt(now.minusHours(13), Status.Pending)
+      timedOutSar2 = subjectAccessRequestSubmittedAt(now.minusHours(14), Status.Pending)
+      timedOutSar3 = subjectAccessRequestSubmittedAt(now.minusHours(21), Status.Pending)
+
+      whenever(alertConfiguration.calculateTimeoutThreshold()).thenReturn(threshold)
+
+      whenever(subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(threshold))
+        .thenReturn(listOf(timedOutSar1, timedOutSar2, timedOutSar3))
+    }
+
+
+    @Test
+    fun `should set status to Errored for requests submitted before timeout threshold`() {
+      whenever(subjectAccessRequestRepository.updateStatusToErrorSubmittedBefore(any(), eq(threshold)))
+        .thenReturn(1)
+
+      val result = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
+
+      assertThat(result).containsExactlyInAnyOrder(
+        timedOutSar1, timedOutSar2, timedOutSar3
+      )
+
+      verify(subjectAccessRequestRepository, times(3)).updateStatusToErrorSubmittedBefore(
+        capture(sarIdCaptor),
+        eq(threshold),
+      )
+
+      assertThat(sarIdCaptor.allValues).hasSize(3)
+      assertThat(sarIdCaptor.allValues[0]).isEqualTo(timedOutSar1.id)
+      assertThat(sarIdCaptor.allValues[1]).isEqualTo(timedOutSar2.id)
+      assertThat(sarIdCaptor.allValues[2]).isEqualTo(timedOutSar3.id)
+    }
+
+    @Test
+    fun `should not return subject access requests that were not updated successfully`() {
+      whenever(subjectAccessRequestRepository.updateStatusToErrorSubmittedBefore(eq(timedOutSar1.id), eq(threshold)))
+        .thenReturn(1)
+      whenever(subjectAccessRequestRepository.updateStatusToErrorSubmittedBefore(eq(timedOutSar2.id), eq(threshold)))
+        .thenReturn(0)
+      whenever(subjectAccessRequestRepository.updateStatusToErrorSubmittedBefore(eq(timedOutSar3.id), eq(threshold)))
+        .thenReturn(1)
+
+      val result = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
+
+      assertThat(result).containsExactlyInAnyOrder(
+        timedOutSar1, timedOutSar3
+      )
+
+      verify(subjectAccessRequestRepository, times(3)).updateStatusToErrorSubmittedBefore(
+        capture(sarIdCaptor),
+        eq(threshold),
+      )
+
+      assertThat(sarIdCaptor.allValues).hasSize(3)
+      assertThat(sarIdCaptor.allValues[0]).isEqualTo(timedOutSar1.id)
+      assertThat(sarIdCaptor.allValues[1]).isEqualTo(timedOutSar2.id)
+      assertThat(sarIdCaptor.allValues[2]).isEqualTo(timedOutSar3.id)
+    }
+
+    @Test
+    fun `should not update if no timed out subject access requests found`() {
+      whenever(subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(threshold))
+        .thenReturn(emptyList())
+
+      val result = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
+
+      assertThat(result).isEmpty()
+
+      verify(subjectAccessRequestRepository, never()).updateStatusToErrorSubmittedBefore(
+        any(),
+        any(),
+      )
+    }
+
+    private fun subjectAccessRequestSubmittedAt(submittedAt: LocalDateTime, status: Status) = SubjectAccessRequest(
+        id = UUID.randomUUID(),
+        status = status,
+        dateFrom = dateFromFormatted,
+        dateTo = dateToFormatted,
+        sarCaseReferenceNumber = "1234abc",
+        services = "{1,2,4}",
+        nomisId = null,
+        ndeliusCaseReferenceId = "1",
+        requestedBy = "UserName",
+        requestDateTime = submittedAt,
+        claimAttempts = 0,
+      )
+    }
 
   private val nDeliusRequest = CreateSubjectAccessRequestEntity(
     nomisId = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -30,6 +30,7 @@ import org.springframework.security.core.Authentication
 import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.client.DocumentStorageClient
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfiguration
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.RequestTimeoutAlertConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.trackApiEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.controllers.entity.CreateSubjectAccessRequestEntity
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.exceptions.CreateSubjectAccessRequestException
@@ -50,6 +51,7 @@ class SubjectAccessRequestServiceTest {
   private val documentStorageClient: DocumentStorageClient = mock()
   private val telemetryClient: TelemetryClient = mock()
   private val alertConfiguration: AlertsConfiguration = mock()
+  private val requestTimeoutAlertConfig: RequestTimeoutAlertConfiguration = mock()
 
   @Captor
   private lateinit var sarIdCaptor: ArgumentCaptor<UUID>
@@ -390,7 +392,9 @@ class SubjectAccessRequestServiceTest {
       timedOutSar2 = subjectAccessRequestSubmittedAt(now.minusHours(14), Status.Pending)
       timedOutSar3 = subjectAccessRequestSubmittedAt(now.minusHours(21), Status.Pending)
 
-      whenever(alertConfiguration.calculateTimeoutThreshold()).thenReturn(threshold)
+      whenever(alertConfiguration.requestTimeoutAlertConfig).thenReturn(requestTimeoutAlertConfig)
+
+      whenever(requestTimeoutAlertConfig.calculateTimeoutThreshold()).thenReturn(threshold)
 
       whenever(subjectAccessRequestRepository.findAllPendingSubjectAccessRequestsSubmittedBefore(threshold))
         .thenReturn(listOf(timedOutSar1, timedOutSar2, timedOutSar3))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/services/SubjectAccessRequestServiceTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.AdditionalMatchers
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mockito.times
@@ -19,7 +18,6 @@ import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.not
 import org.mockito.kotlin.whenever
 import org.springframework.core.io.InputStreamResource
 import org.springframework.data.domain.Page
@@ -398,7 +396,6 @@ class SubjectAccessRequestServiceTest {
         .thenReturn(listOf(timedOutSar1, timedOutSar2, timedOutSar3))
     }
 
-
     @Test
     fun `should set status to Errored for requests submitted before timeout threshold`() {
       whenever(subjectAccessRequestRepository.updateStatusToErrorSubmittedBefore(any(), eq(threshold)))
@@ -407,7 +404,9 @@ class SubjectAccessRequestServiceTest {
       val result = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
 
       assertThat(result).containsExactlyInAnyOrder(
-        timedOutSar1, timedOutSar2, timedOutSar3
+        timedOutSar1,
+        timedOutSar2,
+        timedOutSar3,
       )
 
       verify(subjectAccessRequestRepository, times(3)).updateStatusToErrorSubmittedBefore(
@@ -433,7 +432,8 @@ class SubjectAccessRequestServiceTest {
       val result = subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold()
 
       assertThat(result).containsExactlyInAnyOrder(
-        timedOutSar1, timedOutSar3
+        timedOutSar1,
+        timedOutSar3,
       )
 
       verify(subjectAccessRequestRepository, times(3)).updateStatusToErrorSubmittedBefore(
@@ -463,19 +463,19 @@ class SubjectAccessRequestServiceTest {
     }
 
     private fun subjectAccessRequestSubmittedAt(submittedAt: LocalDateTime, status: Status) = SubjectAccessRequest(
-        id = UUID.randomUUID(),
-        status = status,
-        dateFrom = dateFromFormatted,
-        dateTo = dateToFormatted,
-        sarCaseReferenceNumber = "1234abc",
-        services = "{1,2,4}",
-        nomisId = null,
-        ndeliusCaseReferenceId = "1",
-        requestedBy = "UserName",
-        requestDateTime = submittedAt,
-        claimAttempts = 0,
-      )
-    }
+      id = UUID.randomUUID(),
+      status = status,
+      dateFrom = dateFromFormatted,
+      dateTo = dateToFormatted,
+      sarCaseReferenceNumber = "1234abc",
+      services = "{1,2,4}",
+      nomisId = null,
+      ndeliusCaseReferenceId = "1",
+      requestedBy = "UserName",
+      requestDateTime = submittedAt,
+      claimAttempts = 0,
+    )
+  }
 
   private val nDeliusRequest = CreateSubjectAccessRequestEntity(
     nomisId = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/BacklogThresholdAlertTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/BacklogThresholdAlertTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfiguration
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.BacklogAlertConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.AlertsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.SubjectAccessRequestService
 
@@ -23,6 +24,7 @@ class BacklogThresholdAlertTest {
   private val subjectAccessRequestService: SubjectAccessRequestService = mock()
   private val alertsService: AlertsService = mock()
   private val alertsConfiguration: AlertsConfiguration = mock()
+  private val backlogAlertConfig: BacklogAlertConfiguration = mock()
 
   @Captor
   private lateinit var exceptionCaptor: ArgumentCaptor<Exception>
@@ -37,8 +39,8 @@ class BacklogThresholdAlertTest {
 
   @BeforeEach
   fun setup() {
-    whenever(alertsConfiguration.backlogThreshold)
-      .thenReturn(100)
+    whenever(alertsConfiguration.backlogAlertConfig).thenReturn(backlogAlertConfig)
+    whenever(backlogAlertConfig.threshold).thenReturn(100)
 
     backlogThresholdAlert = BacklogThresholdAlert(
       subjectAccessRequestService,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsOverdueAlertTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsOverdueAlertTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.AlertsConfiguration
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.config.OverdueAlertConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.OverdueSubjectAccessRequests
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.ReportsOverdueSummary
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.AlertsService
@@ -27,6 +28,7 @@ class ReportsOverdueAlertTest {
 
   private val subjectAccessRequestService: SubjectAccessRequestService = mock()
   private val alertConfiguration: AlertsConfiguration = mock()
+  private val overdueAlertConfig: OverdueAlertConfiguration = mock()
   private val alertsService: AlertsService = mock()
   private val dateTimeNowMinus1Hour = LocalDateTime.now().minusHours(1)
   private val overdueOne: OverdueSubjectAccessRequests = mock()
@@ -43,7 +45,10 @@ class ReportsOverdueAlertTest {
 
   @BeforeEach
   fun setup() {
-    whenever(alertConfiguration.calculateOverdueThreshold())
+    whenever(alertConfiguration.overdueAlertConfig)
+      .thenReturn(overdueAlertConfig)
+
+    whenever(overdueAlertConfig.calculateOverdueThreshold())
       .thenReturn(dateTimeNowMinus1Hour)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlertTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlertTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.timed.alerts
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -38,11 +37,6 @@ class ReportsTimedOutAlertTest {
 
   @Captor
   private lateinit var propertiesCaptor: ArgumentCaptor<Map<String, String>>
-
-  @BeforeEach
-  fun setup() {
-
-  }
 
   @Test
   fun `should not raise alert if no requests were expired`() {
@@ -83,7 +77,7 @@ class ReportsTimedOutAlertTest {
 
     verify(alertsService, times(1)).raiseUnexpectedExceptionAlert(
       capture(errorCaptor),
-      capture(propertiesCaptor)
+      capture(propertiesCaptor),
     )
 
     assertThat(errorCaptor.allValues).hasSize(1)
@@ -108,7 +102,7 @@ class ReportsTimedOutAlertTest {
 
     verify(alertsService, times(1)).raiseUnexpectedExceptionAlert(
       capture(errorCaptor),
-      capture(propertiesCaptor)
+      capture(propertiesCaptor),
     )
 
     assertThat(errorCaptor.allValues).hasSize(1)
@@ -138,7 +132,7 @@ class ReportsTimedOutAlertTest {
 
     verify(alertsService, times(1)).raiseUnexpectedExceptionAlert(
       capture(errorCaptor),
-      capture(propertiesCaptor)
+      capture(propertiesCaptor),
     )
 
     assertThat(errorCaptor.allValues).hasSize(1)
@@ -146,5 +140,4 @@ class ReportsTimedOutAlertTest {
     assertThat(errorCaptor.allValues[0].message).isEqualTo("ReportsTimedOutAlert threw unexpected exception")
     assertThat(propertiesCaptor.allValues[0]).isNull()
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlertTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlertTest.kt
@@ -1,20 +1,150 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.timed.alerts
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.AlertsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.SubjectAccessRequestService
 
+@ExtendWith(MockitoExtension::class)
 class ReportsTimedOutAlertTest {
 
   private val alertsService: AlertsService = mock()
   private val subjectAccessRequestService: SubjectAccessRequestService = mock()
+  private val expiredSar1: SubjectAccessRequest = mock()
+  private val thrownException = RuntimeException("KABOOOM!")
 
-  private lateinit var timeoutAlert: ReportsTimedOutAlert
+  private val timeoutAlert = ReportsTimedOutAlert(
+    subjectAccessRequestService = subjectAccessRequestService,
+    alertsService = alertsService,
+  )
+
+  @Captor
+  private lateinit var errorCaptor: ArgumentCaptor<Exception>
+
+  @Captor
+  private lateinit var propertiesCaptor: ArgumentCaptor<Map<String, String>>
 
   @BeforeEach
   fun setup() {
 
+  }
+
+  @Test
+  fun `should not raise alert if no requests were expired`() {
+    whenever(subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold())
+      .thenReturn(emptyList())
+
+    timeoutAlert.execute()
+
+    verify(subjectAccessRequestService, times(1))
+      .expirePendingRequestsSubmittedBeforeThreshold()
+
+    verifyNoInteractions(alertsService)
+  }
+
+  @Test
+  fun `should raise alert if 1 or more requests were expired`() {
+    val timedOutRequests = listOf(expiredSar1)
+
+    whenever(subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold())
+      .thenReturn(timedOutRequests)
+
+    timeoutAlert.execute()
+
+    verify(subjectAccessRequestService, times(1))
+      .expirePendingRequestsSubmittedBeforeThreshold()
+
+    verify(alertsService, times(1)).raiseReportsTimedOutAlert(timedOutRequests)
+  }
+
+  @Test
+  fun `should raise unexpected error alert subjectAccessRequestService throws exception`() {
+    whenever(subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold())
+      .thenThrow(thrownException)
+
+    timeoutAlert.execute()
+
+    verify(subjectAccessRequestService, times(1)).expirePendingRequestsSubmittedBeforeThreshold()
+
+    verify(alertsService, times(1)).raiseUnexpectedExceptionAlert(
+      capture(errorCaptor),
+      capture(propertiesCaptor)
+    )
+
+    assertThat(errorCaptor.allValues).hasSize(1)
+    assertThat(errorCaptor.allValues[0].cause).isEqualTo(thrownException)
+    assertThat(errorCaptor.allValues[0].message).isEqualTo("ReportsTimedOutAlert threw unexpected exception")
+    assertThat(propertiesCaptor.allValues[0]).isNull()
+  }
+
+  @Test
+  fun `should raise unexpected error alert alertsService throws exception`() {
+    whenever(subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold())
+      .thenReturn(listOf(expiredSar1))
+
+    whenever(alertsService.raiseReportsTimedOutAlert(listOf(expiredSar1)))
+      .thenThrow(thrownException)
+
+    timeoutAlert.execute()
+
+    verify(subjectAccessRequestService, times(1)).expirePendingRequestsSubmittedBeforeThreshold()
+
+    verify(alertsService, times(1)).raiseReportsTimedOutAlert(listOf(expiredSar1))
+
+    verify(alertsService, times(1)).raiseUnexpectedExceptionAlert(
+      capture(errorCaptor),
+      capture(propertiesCaptor)
+    )
+
+    assertThat(errorCaptor.allValues).hasSize(1)
+    assertThat(errorCaptor.allValues[0].cause).isEqualTo(thrownException)
+    assertThat(errorCaptor.allValues[0].message).isEqualTo("ReportsTimedOutAlert threw unexpected exception")
+    assertThat(propertiesCaptor.allValues[0]).isNull()
+  }
+
+  @Test
+  fun `should throw exception if the alerts service raise unexpected error throws exception`() {
+    whenever(subjectAccessRequestService.expirePendingRequestsSubmittedBeforeThreshold())
+      .thenReturn(listOf(expiredSar1))
+
+    whenever(alertsService.raiseReportsTimedOutAlert(listOf(expiredSar1)))
+      .thenThrow(thrownException)
+
+    whenever(alertsService.raiseUnexpectedExceptionAlert(any(), isNull()))
+      .thenThrow(thrownException)
+
+    val exception = assertThrows<RuntimeException> { timeoutAlert.execute() }
+
+    assertThat(exception).isEqualTo(thrownException)
+
+    verify(subjectAccessRequestService, times(1)).expirePendingRequestsSubmittedBeforeThreshold()
+
+    verify(alertsService, times(1)).raiseReportsTimedOutAlert(listOf(expiredSar1))
+
+    verify(alertsService, times(1)).raiseUnexpectedExceptionAlert(
+      capture(errorCaptor),
+      capture(propertiesCaptor)
+    )
+
+    assertThat(errorCaptor.allValues).hasSize(1)
+    assertThat(errorCaptor.allValues[0].cause).isEqualTo(thrownException)
+    assertThat(errorCaptor.allValues[0].message).isEqualTo("ReportsTimedOutAlert threw unexpected exception")
+    assertThat(propertiesCaptor.allValues[0]).isNull()
   }
 
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlertTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestapi/timed/alerts/ReportsTimedOutAlertTest.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestapi.timed.alerts
+
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.AlertsService
+import uk.gov.justice.digital.hmpps.subjectaccessrequestapi.services.SubjectAccessRequestService
+
+class ReportsTimedOutAlertTest {
+
+  private val alertsService: AlertsService = mock()
+  private val subjectAccessRequestService: SubjectAccessRequestService = mock()
+
+  private lateinit var timeoutAlert: ReportsTimedOutAlert
+
+  @BeforeEach
+  fun setup() {
+
+  }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,12 +13,16 @@ server:
 application:
   alerts:
     reports-overdue:
-      alert-frequency: 720
+      alert-interval-minutes: 720
       threshold: 12
       threshold-unit: HOURS
     backlog-threshold:
-      alert-frequency: 720
+      alert-interval-minutes: 720
       threshold: 100
+    report-timeout:
+      alert-interval-minutes: 720
+      threshold:  48
+      threshold-unit: HOURS
 
 management.endpoint:
   health.cache.time-to-live: 0


### PR DESCRIPTION
Added new scheduled job to fail pending alerts that were submitted before a configurable threshold. Defaults
- Check frequency 12 hours
- Threshold 48 hours