### PR TITLE
HAAR-4160: Update service config db scripts to replace delete due to foreign key constraint violation

### DIFF
--- a/scripts/db-data/create_dev_services_configuration.sql
+++ b/scripts/db-data/create_dev_services_configuration.sql
@@ -1,5 +1,4 @@
 -- Insert service configuration for the Dev environment
-DELETE FROM service_configuration;
 INSERT INTO service_configuration (service_name, label, url, list_order)
 VALUES
     ('G1', 'G1', 'G1', 1),
@@ -29,4 +28,8 @@ VALUES
     ('hmpps-approved-premises-api', 'Approved Premises', 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk', 25),
     ('make-recall-decision-api', 'Consider a Recall', 'https://make-recall-decision-api-dev.hmpps.service.justice.gov.uk', 26),
     ('hmpps-health-and-medication-api', 'Health and Medication', 'https://health-and-medication-api-dev.hmpps.service.justice.gov.uk', 27),
-    ('wiremock-test-service-api', 'Wiremock Test Service', 'http://hmpps-subject-access-request-worker-wiremock', 9999);
+    ('wiremock-test-service-api', 'Wiremock Test Service', 'http://hmpps-subject-access-request-worker-wiremock', 9999)
+ON CONFLICT (service_name) DO UPDATE SET
+    label = EXCLUDED.label,
+    url = EXCLUDED.url,
+    list_order = EXCLUDED.list_order;

--- a/scripts/db-data/create_preprod_services_configuration.sql
+++ b/scripts/db-data/create_preprod_services_configuration.sql
@@ -1,6 +1,5 @@
 -- Insert service configuration for the Preprod environment
 
-DELETE FROM service_configuration;
 INSERT INTO service_configuration (service_name, label, url, list_order)
 VALUES
     ('G1', 'G1', 'G1', 1),
@@ -29,4 +28,8 @@ VALUES
     ('hmpps-interventions-service', 'Refer and Monitor an Intervention', 'https://hmpps-interventions-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk', 24),
     ('hmpps-approved-premises-api', 'Approved Premises', 'https://approved-premises-api-preprod.hmpps.service.justice.gov.uk', 25),
     ('make-recall-decision-api', 'Consider a Recall', 'https://make-recall-decision-api-preprod.hmpps.service.justice.gov.uk', 26),
-    ('hmpps-health-and-medication-api', 'Health and Medication', 'https://health-and-medication-api-preprod.hmpps.service.justice.gov.uk', 27);
+    ('hmpps-health-and-medication-api', 'Health and Medication', 'https://health-and-medication-api-preprod.hmpps.service.justice.gov.uk', 27)
+ON CONFLICT (service_name) DO UPDATE SET
+    label = EXCLUDED.label,
+    url = EXCLUDED.url,
+    list_order = EXCLUDED.list_order;

--- a/scripts/db-data/create_prod_services_configuration.sql
+++ b/scripts/db-data/create_prod_services_configuration.sql
@@ -1,6 +1,5 @@
 -- Insert service configuration for the Prod environment
 
-DELETE FROM service_configuration;
 INSERT INTO service_configuration (service_name, label, url, list_order)
 VALUES
     ('G1', 'G1', 'G1', 1),
@@ -28,4 +27,8 @@ VALUES
     ('hmpps-accredited-programmes-api', 'Accredited Programmes', 'https://accredited-programmes-api.hmpps.service.justice.gov.uk', 23),
     ('hmpps-interventions-service', 'Refer and Monitor an Intervention', 'https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk', 24),
     ('hmpps-approved-premises-api', 'Approved Premises', 'https://approved-premises-api.hmpps.service.justice.gov.uk', 25),
-    ('make-recall-decision-api', 'Consider a Recall', 'https://make-recall-decision-api.hmpps.service.justice.gov.uk', 26);
+    ('make-recall-decision-api', 'Consider a Recall', 'https://make-recall-decision-api.hmpps.service.justice.gov.uk', 26)
+ON CONFLICT (service_name) DO UPDATE SET
+    label = EXCLUDED.label,
+    url = EXCLUDED.url,
+    list_order = EXCLUDED.list_order;


### PR DESCRIPTION
It's not possible to delete the service configurations records due to the foreign constraint on the service_summary table, so have replaced that with a ON CONFLICT UPDATE statement which allows for either inserting or updating existing records.
This might not work when the ordering needs to change due to the unique constraint on the list_order column, but hopefully that won't need to be done again, or if it does then we'll need to re-assess the best way to do this.