### PR TITLE
HAAR-5152: Remove not null constraint for optional fields

### DIFF
--- a/src/main/resources/db/migration/V1_21__sar_archive_drop_template_versino_not_null.sql
+++ b/src/main/resources/db/migration/V1_21__sar_archive_drop_template_versino_not_null.sql
@@ -1,0 +1,7 @@
+/* Template Version columns will be null if Service hasn't been migrated yet */
+ALTER TABLE subject_access_request_archive ALTER COLUMN template_version_id DROP NOT NULL;
+ALTER TABLE subject_access_request_archive ALTER COLUMN template_version_status DROP NOT NULL;
+ALTER TABLE subject_access_request_archive ALTER COLUMN template_version_version DROP NOT NULL;
+ALTER TABLE subject_access_request_archive ALTER COLUMN template_version_created_at DROP NOT NULL;
+ALTER TABLE subject_access_request_archive ALTER COLUMN template_version_published_at DROP NOT NULL;
+ALTER TABLE subject_access_request_archive ALTER COLUMN template_version_file_hash DROP NOT NULL;


### PR DESCRIPTION
Fix for defect - Template version fields will be null for services that have not migrated templates yet. Script drops the not null constraint to allow for those cases.